### PR TITLE
fix lint violations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,7 @@ android {
     }
 
     lintOptions {
+        abortOnError false
         disable 'InvalidPackage'
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,6 @@ android {
     }
 
     lintOptions {
-        abortOnError false
         disable 'InvalidPackage'
     }
 

--- a/app/src/main/res/layout/activity_web_view.xml
+++ b/app/src/main/res/layout/activity_web_view.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:tools="http://schemas.android.com/tools"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <android.support.v7.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            android:elevation="@dimen/elevation"
-            app:elevation="@dimen/elevation"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                android:elevation="@dimen/elevation"
+                app:elevation="@dimen/elevation"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+                tools:targetApi="lollipop"/>
 
         <WebView
             android:id="@+id/webview"

--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -15,15 +15,16 @@
             android:orientation="vertical">
 
             <android.support.design.widget.TabLayout
-                android:id="@+id/tab_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@color/theme500"
-                android:elevation="@dimen/elevation"
-                app:elevation="@dimen/elevation"
-                app:tabIndicatorColor="@color/accent100"
-                app:tabMode="fixed"
-                app:tabTextColor="@color/grey300" />
+                    android:id="@+id/tab_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/theme500"
+                    android:elevation="@dimen/elevation"
+                    app:elevation="@dimen/elevation"
+                    app:tabIndicatorColor="@color/accent100"
+                    app:tabMode="fixed"
+                    app:tabTextColor="@color/grey300"
+                    tools:targetApi="lollipop"/>
 
             <io.github.droidkaigi.confsched.widget.RtlViewPager
                 android:id="@+id/view_pager"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,6 +28,7 @@
     <string name="settings">محيط</string>
     <string name="sponsors">كفيل</string>
     <string name="about">التفاصيل</string>
+    <string name="search">بحث</string>
 
     <string name="map_main_name">استقبال، مكان الرئيسي</string>
     <string name="map_main_building">70 الذكرى قاعة</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -28,6 +28,7 @@
     <string name="settings">設定</string>
     <string name="sponsors">スポンサー</string>
     <string name="about">詳細</string>
+    <string name="search">検索</string>
 
     <string name="map_main_name">受付・基調講演会場</string>
     <string name="map_main_building">70周年記念講堂</string>

--- a/app/src/main/res/values/strings_urls.xml
+++ b/app/src/main/res/values/strings_urls.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:ignore="MissingTranslation" >
     <string name="about_inquiry_url">https://docs.google.com/forms/d/1fpxZOqprZyzBgMBb7HCCrq538oOzfzWkOMpItRqF-ro/viewform</string>
     <string name="bug_report_url">https://github.com/konifar/droidkaigi2016/issues/new?title=%5BBug%20Report%5D&amp;body=%23%20Problem%0A%0A%23%20Solution</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Text -->
     <style name="TextTitle">
@@ -50,11 +50,11 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingBottom">@dimen/tag_padding_vertical</item>
-        <item name="android:paddingEnd">@dimen/tag_padding_horizontal</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/tag_padding_horizontal</item>
         <item name="android:paddingLeft">@dimen/tag_padding_horizontal</item>
         <item name="android:paddingTop">@dimen/tag_padding_vertical</item>
         <item name="android:paddingRight">@dimen/tag_padding_horizontal</item>
-        <item name="android:paddingStart">@dimen/tag_padding_horizontal</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/tag_padding_horizontal</item>
         <item name="android:textSize">@dimen/text_small</item>
         <item name="android:textColor">@color/grey600</item>
     </style>
@@ -94,8 +94,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginLeft">@dimen/spacing_small</item>
         <item name="android:layout_marginRight">@dimen/spacing_small</item>
-        <item name="android:layout_marginEnd">@dimen/spacing_small</item>
-        <item name="android:layout_marginStart">@dimen/spacing_small</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/spacing_small</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing_small</item>
         <item name="android:ellipsize">end</item>
         <item name="android:lines">1</item>
         <item name="android:textSize">@dimen/text_xlarge</item>

--- a/app/src/main/res/values/styles_about.xml
+++ b/app/src/main/res/values/styles_about.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="AboutTitle">
         <item name="android:layout_width">match_parent</item>
@@ -14,17 +14,17 @@
     <style name="AboutRow">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginEnd">@dimen/spacing_negative</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/spacing_negative</item>
         <item name="android:layout_marginLeft">@dimen/spacing_negative</item>
         <item name="android:layout_marginRight">@dimen/spacing_negative</item>
-        <item name="android:layout_marginStart">@dimen/spacing_negative</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing_negative</item>
         <item name="android:background">@drawable/clickable</item>
         <item name="android:clickable">true</item>
         <item name="android:paddingBottom">@dimen/spacing_large</item>
-        <item name="android:paddingEnd">@dimen/spacing</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/spacing</item>
         <item name="android:paddingLeft">@dimen/spacing</item>
         <item name="android:paddingRight">@dimen/spacing</item>
-        <item name="android:paddingStart">@dimen/spacing</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing</item>
         <item name="android:paddingTop">@dimen/spacing_large</item>
         <item name="android:textColor">@color/theme500</item>
         <item name="android:textStyle">bold</item>

--- a/app/src/main/res/values/styles_sponsor.xml
+++ b/app/src/main/res/values/styles_sponsor.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="SponsorCategory">
         <item name="android:layout_width">match_parent</item>
@@ -18,10 +18,10 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:orientation">horizontal</item>
-        <item name="android:paddingEnd">@dimen/spacing</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/spacing</item>
         <item name="android:paddingLeft">@dimen/spacing</item>
         <item name="android:paddingRight">@dimen/spacing_small</item>
-        <item name="android:paddingStart">@dimen/spacing_small</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing_small</item>
     </style>
 
 </resources>


### PR DESCRIPTION
**edit**: this pr only includes lint-violation fixes. Enabling `abortOnError` is a next time issue.


---

Do not disable `lintOptions.abortOnError`, which can find critical errors.

This pull-request re-enable `abortOnError` and supress critical lint errors.

FYI: https://github.com/konifar/droidkaigi2016/pull/129 enables `./gradlew check` which includes `./gradlew lint`.

@konifar: you can reject this pull-request if you don't like this. It might cause a lot of CI failures :)