### PR TITLE
unsubscribe() when MainActivity is destroyed.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
@@ -83,6 +83,12 @@ public class MainActivity extends AppCompatActivity
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        subscription.unsubscribe();
+    }
+
     private void initView() {
         setSupportActionBar(binding.toolbar);
         ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this,


### PR DESCRIPTION
This fixes some crashes of "Can not perform this action after onSaveInstanceState" and also fixes the leak of MainActivity instance when regeneration of MainActivity such as changing the locale.

Perhaps this PR fixes #119.