### PR TITLE
Adds first UI tests for SessionDetailActivity using Espresso.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ android {
         versionCode versionMajor * 100 + versionMinor * 10 + versionPatch
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        com.android.ddmlib.DdmPreferences.setTimeOut(60000)
     }
 
     packagingOptions {
@@ -167,5 +168,10 @@ dependencies {
     androidTestCompile('com.squareup.assertj:assertj-android:1.0.1') {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.1') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestCompile('com.android.support.test.espresso:espresso-intents:2.2.1') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.android.ddmlib.DdmPreferences
+
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'me.tatarka.retrolambda'
@@ -33,7 +35,10 @@ android {
         versionCode versionMajor * 100 + versionMinor * 10 + versionPatch
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        com.android.ddmlib.DdmPreferences.setTimeOut(60000)
+
+        // Referred to https://github.com/circleci/EspressoSample to make the Espresso tests
+        // work on CircleCI.
+        DdmPreferences.setTimeOut(60000)
     }
 
     packagingOptions {

--- a/app/src/androidTest/java/io/github/droidkaigi/confsched/activity/SessionDetailActivityTest.java
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched/activity/SessionDetailActivityTest.java
@@ -1,0 +1,128 @@
+package io.github.droidkaigi.confsched.activity;
+
+/**
+ * UI tests for {@link SessionDetailActivity} using Espresso.
+ */
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.MediumTest;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import io.github.droidkaigi.confsched.R;
+import io.github.droidkaigi.confsched.model.Category;
+import io.github.droidkaigi.confsched.model.Place;
+import io.github.droidkaigi.confsched.model.Session;
+import io.github.droidkaigi.confsched.model.Speaker;
+import io.github.droidkaigi.confsched.util.AppUtil;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.Intents.intending;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasData;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.isInternal;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+@MediumTest
+public class SessionDetailActivityTest {
+
+    private static final Session SESSION = new Session();
+    private static final String DESCRIPTION = "description";
+    private static final Date STIME = new GregorianCalendar(2016, 2, 19, 10, 0).getTime();
+    private static final Date ETIME = new GregorianCalendar(2016, 2, 19, 11, 0).getTime();
+
+    private static final Speaker SPEAKER = new Speaker();
+    private static final String SPEAKER_NAME = "speaker_name";
+    private static final String GITHUB_NAME = "github_name";
+    private static final String TWITTER_NAME = "twitter_name";
+
+    private static final Category CATEGORY = new Category();
+    private static final String CATEGORY_NAME = "category_name";
+
+    private static final Place PLACE = new Place();
+    private static final String PLACE_NAME = "place_name";
+
+    static {
+        SPEAKER.id = 1;
+        SPEAKER.name = SPEAKER_NAME;
+        SPEAKER.githubName = GITHUB_NAME;
+        SPEAKER.twitterName = TWITTER_NAME;
+
+        CATEGORY.id = 2;
+        CATEGORY.name = CATEGORY_NAME;
+
+        PLACE.id = 3;
+        PLACE.name = PLACE_NAME;
+
+        SESSION.id = 100;
+        SESSION.description = DESCRIPTION;
+        SESSION.speaker = SPEAKER;
+        SESSION.category = CATEGORY;
+        SESSION.place = PLACE;
+        SESSION.stime = STIME;
+        SESSION.etime = ETIME;
+    }
+
+    @Rule
+    public IntentsTestRule<SessionDetailActivity> activityRule = new IntentsTestRule<>(
+            SessionDetailActivity.class, true, false);
+
+    @Before
+    public void setUp() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Intent intent = SessionDetailActivity.createIntent(context, SESSION);
+        // The third argument of the constructor for ActivityTestRule needs to be false as explained
+        // in the Javadoc for ActivityTestRule#launchActivity
+        // http://developer.android.com/reference/android/support/test/rule/ActivityTestRule.html#launchActivity(android.content.Intent)
+        activityRule.launchActivity(intent);
+
+        // By default Espresso Intents does not stub any Intents. Stubbing needs to be setup before
+        // every test run. In this case all external Intents will be blocked.
+        intending(not(isInternal()))
+                .respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, null));
+
+
+    }
+
+    @Test
+    public void testInitialViews() {
+        onView(withId(R.id.txt_speaker_name)).check(matches(withText(SPEAKER_NAME)));
+        onView(withId(R.id.txt_category)).check(matches(withText(CATEGORY_NAME)));
+        onView(withId(R.id.txt_place)).check(matches(withText(PLACE_NAME)));
+        onView(withId(R.id.txt_description)).check(matches(withText(DESCRIPTION)));
+    }
+
+    @Test
+    public void testClickTwitterIcon() {
+        onView(withId(R.id.img_twitter)).perform(click());
+
+        intended(
+                allOf(hasAction(Intent.ACTION_VIEW), hasData(AppUtil.getTwitterUrl(TWITTER_NAME))));
+    }
+
+    @Test
+    public void testClickGitHubIcon() {
+        onView(withId(R.id.img_github)).perform(click());
+
+        intended(allOf(hasAction(Intent.ACTION_VIEW), hasData(AppUtil.getGitHubUrl(GITHUB_NAME))));
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionDetailActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionDetailActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
@@ -32,7 +33,8 @@ public class SessionDetailActivity extends AppCompatActivity {
     private ActivitySessionDetailBinding binding;
     private Session session;
 
-    private static Intent createIntent(@NonNull Context context, @NonNull Session session) {
+    @VisibleForTesting
+    static Intent createIntent(@NonNull Context context, @NonNull Session session) {
         Intent intent = new Intent(context, SessionDetailActivity.class);
         intent.putExtra(Session.class.getSimpleName(), Parcels.wrap(session));
         return intent;

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -214,6 +214,7 @@
                     app:categoryVividColor="@{session.category}" />
 
                 <TextView
+                    android:id="@+id/txt_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:lineSpacingExtra="@dimen/line_spacing_large"

--- a/circle.yml
+++ b/circle.yml
@@ -23,10 +23,10 @@ test:
         parallel: true
     - circle-android wait-for-boot
   override:
-    # unlock the emulator screen
+      # unlock the emulator screen. Referred to https://github.com/circleci/EspressoSample
     - sleep 30
     - adb shell input keyevent 82
-    - ./gradlew clean assembleProductionDebug check connectedAndroidTest
+    - ./gradlew clean assembleProductionDebug check connectedAndroidTest -PdisablePreDex
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ machine:
   environment:
     ANDROID_HOME: /usr/local/android-sdk-linux
     JAVA_OPTS: "-Xms512m -Xmx1024m"
+    TERM: "dumb"
+    ADB_INSTALL_TIMEOUT: "10"
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
@@ -15,8 +17,16 @@ dependencies:
     - ./gradlew dependencies
 
 test:
+  pre:
+    - emulator -avd circleci-android22 -no-audio -no-window:
+        background: true
+        parallel: true
+    - circle-android wait-for-boot
   override:
-    - ./gradlew clean assembleProductionDebug check
+    # unlock the emulator screen
+    - sleep 30
+    - adb shell input keyevent 82
+    - ./gradlew clean assembleProductionDebug check connectedAndroidTest
 
 deployment:
   production:


### PR DESCRIPTION
The tests verify initial views are correctly rendered and external Intents are
correctly thrown when clicking the Twitter/GitHub icons by launching the SessionDetailActivity
on connected emulators or devices.

Note that this is the first time for me to setup an emulator on CircleCI.
I referred to [this document](https://circleci.com/docs/android) on how to run an emulator on the CircleCI.
If the pre-submit fails, let me play around the setup until the pre-submit becomes green.