### PR TITLE
Fix base color of shape drawable is falling back to black on API 16

### DIFF
--- a/app/src/main/res/drawable/tag_language.xml
+++ b/app/src/main/res/drawable/tag_language.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <solid android:color="@null" />
     <stroke
         android:width="@dimen/tag_border_width"
         android:color="@color/grey200" />


### PR DESCRIPTION
If `<shape>` does not provide child `<solid>`, it's base color fallbacks to black pre API 17.

Here's screenshot of Xperia SX (SO-05D) (4.1.2).

### Before
![so05d-1](https://cloud.githubusercontent.com/assets/1487505/12980087/3100ad22-d11e-11e5-8647-6bd27347b033.png)

### After
![so05d-2](https://cloud.githubusercontent.com/assets/1487505/12980089/336c5732-d11e-11e5-8ed6-12a1f0759216.png)
