### PR TITLE
Remove espresso test temporary.

### DIFF
--- a/app/src/androidTest/java/io/github/droidkaigi/confsched/activity/SessionDetailActivityTest.java
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched/activity/SessionDetailActivityTest.java
@@ -4,11 +4,6 @@ package io.github.droidkaigi.confsched.activity;
  * UI tests for {@link SessionDetailActivity} using Espresso.
  */
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Context;
@@ -17,6 +12,12 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.MediumTest;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -41,6 +42,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 
+@Ignore
 @RunWith(AndroidJUnit4.class)
 @MediumTest
 public class SessionDetailActivityTest {

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ machine:
   environment:
     ANDROID_HOME: /usr/local/android-sdk-linux
     JAVA_OPTS: "-Xms512m -Xmx1024m"
-    TERM: "dumb"
-    ADB_INSTALL_TIMEOUT: "10"
+#    TERM: "dumb"
+#    ADB_INSTALL_TIMEOUT: "10"
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
@@ -17,16 +17,17 @@ dependencies:
     - ./gradlew dependencies
 
 test:
-  pre:
-    - emulator -avd circleci-android22 -no-audio -no-window:
-        background: true
-        parallel: true
-    - circle-android wait-for-boot
+#  pre:
+#    - emulator -avd circleci-android22 -no-audio -no-window:
+#        background: true
+#        parallel: true
+#    - circle-android wait-for-boot
   override:
       # unlock the emulator screen. Referred to https://github.com/circleci/EspressoSample
-    - sleep 30
-    - adb shell input keyevent 82
-    - ./gradlew clean assembleProductionDebug check connectedAndroidTest -PdisablePreDex
+#    - sleep 30
+#    - adb shell input keyevent 82
+#    - ./gradlew clean assembleProductionDebug check connectedAndroidTest -PdisablePreDex
+    - ./gradlew clean assembleProductionDebug check
 
 deployment:
   production:


### PR DESCRIPTION
Remove Espresso test temporary. Because UI test is heavy, CI test is not stable and take so long time.