### PR TITLE
Remove debug build deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,10 +27,11 @@ test:
 #    - sleep 30
 #    - adb shell input keyevent 82
 #    - ./gradlew clean assembleProductionDebug check connectedAndroidTest -PdisablePreDex
-    - ./gradlew clean assembleProductionRelease check
+    - ./gradlew clean assembleProductionDebug check
 
 general:
   artifacts:
+    # TODO Fix this because this section run before deployment section, release build apk is nothing.
     - "app/build/outputs/apk/app-production-release.apk" # relative to the build directory
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ test:
 general:
   artifacts:
     - "app/build/outputs/apk/app-production-release.apk" # relative to the build directory
-    - "app/build/outputs/apk/app-develop-debug.apk" # relative to the build directory
+#    - "app/build/outputs/apk/app-develop-debug.apk" # relative to the build directory
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,6 @@ test:
 general:
   artifacts:
     - "app/build/outputs/apk/app-production-release.apk" # relative to the build directory
-#    - "app/build/outputs/apk/app-develop-debug.apk" # relative to the build directory
 
 deployment:
   production:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 GIT_HASH=`git rev-parse --short HEAD`
 
 # For α version. Remove this after 1.0.0 release.
-./gradlew clean assembleProductionDebug
-curl -F "file=@app/build/outputs/apk/app-production-debug.apk" -F "token=${DEPLOY_GATE_API_KEY}" -F "message=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" -F "distribution_key=0d34ff6b3ccedf2a76771d9b6002c55b4f0aac1f" -F "release_note=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" https://deploygate.com/api/users/konifar/apps
+# ./gradlew clean assembleProductionDebug
+# curl -F "file=@app/build/outputs/apk/app-production-debug.apk" -F "token=${DEPLOY_GATE_API_KEY}" -F "message=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" -F "distribution_key=0d34ff6b3ccedf2a76771d9b6002c55b4f0aac1f" -F "release_note=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" https://deploygate.com/api/users/konifar/apps
 
 # For β version. Remove comment out after first ci success.
 ./gradlew clean assembleProductionRelease

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,9 +1,3 @@
 GIT_HASH=`git rev-parse --short HEAD`
 
-# For α version. Remove this after 1.0.0 release.
-# ./gradlew clean assembleProductionDebug
-# curl -F "file=@app/build/outputs/apk/app-production-debug.apk" -F "token=${DEPLOY_GATE_API_KEY}" -F "message=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" -F "distribution_key=0d34ff6b3ccedf2a76771d9b6002c55b4f0aac1f" -F "release_note=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" https://deploygate.com/api/users/konifar/apps
-
-# For β version. Remove comment out after first ci success.
-./gradlew clean assembleProductionRelease
 curl -F "file=@app/build/outputs/apk/app-production-release.apk" -F "token=${DEPLOY_GATE_API_KEY}" -F "message=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" -F "distribution_key=901884d8a27b8bd9c368109b0cc5c941a6821076" -F "release_note=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" https://deploygate.com/api/users/konifar/apps

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,4 @@
 GIT_HASH=`git rev-parse --short HEAD`
 
+./gradlew clean assembleProductionRelease
 curl -F "file=@app/build/outputs/apk/app-production-release.apk" -F "token=${DEPLOY_GATE_API_KEY}" -F "message=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" -F "distribution_key=901884d8a27b8bd9c368109b0cc5c941a6821076" -F "release_note=https://github.com/konifar/droidkaigi2016/tree/${GIT_HASH} https://circleci.com/gh/konifar/droidkaigi2016/${CIRCLE_BUILD_NUM}" https://deploygate.com/api/users/konifar/apps


### PR DESCRIPTION
Removed debug build deploy to Deploygate, because `1.0.0` was already released.