### PR TITLE
Displays the chrome custom tab at the link click of WebViewActivity

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/WebViewActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/WebViewActivity.java
@@ -49,7 +49,8 @@ public class WebViewActivity extends AppCompatActivity {
         binding.webview.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                return false;
+                AppUtil.showWebPage(WebViewActivity.this, url);
+                return true;
             }
         });
         binding.webview.loadUrl(url);


### PR DESCRIPTION
Thank you for amazing app!!

Now, WebViewActivity is not enabled JavaScript. And WebViewActivity can link move.
So WebViewActivity displays a page not completely.
If you enabled JavaScript, WebViewActivity contains the vulnerability.

I wrote code that displays the chrome custom tab at the link click of WebViewActivity.