### PR TITLE
Modify method prefix from "provides" to "provide"

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
@@ -43,7 +43,7 @@ public class AppModule {
 
     @Singleton
     @Provides
-    public Tracker providesGoogleAnalyticsTracker(Context context) {
+    public Tracker provideGoogleAnalyticsTracker(Context context) {
         GoogleAnalytics ga = GoogleAnalytics.getInstance(context);
         Tracker tracker = ga.newTracker(BuildConfig.GA_TRACKING_ID);
         tracker.enableAdvertisingIdCollection(true);


### PR DESCRIPTION
Modify tinily to keep injection provider method name consistent.

Renamed from `provides...` to `provide...` as GoogleAanalyticsTracker is the only provider method that has `provides` prefix. 