### PR TITLE
change unfocused tab color

### DIFF
--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -23,7 +23,7 @@
                     app:elevation="@dimen/elevation"
                     app:tabIndicatorColor="@color/accent100"
                     app:tabMode="fixed"
-                    app:tabTextColor="@color/grey300"
+                    app:tabTextColor="@color/white_alpha_40"
                     tools:targetApi="lollipop"/>
 
             <io.github.droidkaigi.confsched.widget.RtlViewPager


### PR DESCRIPTION
I fixed unfocused tabs text color along the material design guideline ( https://www.google.com/design/spec/components/tabs.html ).

> Unfocused tab color: #fff 70%

### before

![image](https://cloud.githubusercontent.com/assets/4554061/13028204/8682cab2-d2ab-11e5-8c39-beefcf8762b9.png)

### after

![image](https://cloud.githubusercontent.com/assets/4554061/13028197/41034ec6-d2ab-11e5-844a-7841ccbd2a2e.png)