### PR TITLE
Fix distorted speaker image.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/util/DataBindingAttributeUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/DataBindingAttributeUtil.java
@@ -37,6 +37,7 @@ public class DataBindingAttributeUtil {
             Picasso.with(imageView.getContext())
                     .load(imageUrl)
                     .resize(size, size)
+                    .centerInside()
                     .placeholder(R.drawable.ic_speaker_placeholder)
                     .error(R.drawable.ic_speaker_placeholder)
                     .transform(new CropCircleTransformation())


### PR DESCRIPTION
Use `centerInside()` for non-square speaker images.

Before | After
------------ | -------------
![now](https://cloud.githubusercontent.com/assets/500072/13028674/0d2911ea-d2b9-11e5-94ed-4a28dabb3719.png) | ![fixed](https://cloud.githubusercontent.com/assets/500072/13028673/0d2351d8-d2b9-11e5-91da-57bd857ecf1a.png)