### PR TITLE
fix edit text cursor

### DIFF
--- a/app/src/main/res/drawable/rect_edit_text_cursor.xml
+++ b/app/src/main/res/drawable/rect_edit_text_cursor.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="@color/white_alpha_95" />
+    <size android:width="2dp" />
+
+</shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -70,7 +70,7 @@
         <item name="android:drawableEnd">@drawable/ic_close_white_18dp</item>
         <item name="android:imeOptions">actionSearch</item>
         <item name="android:inputType">text</item>
-        <item name="android:textCursorDrawable">@color/white_alpha_95</item>
+        <item name="android:textCursorDrawable">@drawable/rect_edit_text_cursor</item>
         <item name="android:maxLines">1</item>
         <item name="android:paddingRight">@dimen/spacing_small</item>
         <item name="android:textColor">@color/white</item>


### PR DESCRIPTION
Since the drawable rather than color resource has been specified, the input cursor of EditText did not appear.

### before
![2016-02-14 0 48 32](https://cloud.githubusercontent.com/assets/1172478/13028779/6b983e88-d2bc-11e5-880d-bff04b915498.png)

### fixed
![2016-02-14 1 33 58](https://cloud.githubusercontent.com/assets/1172478/13028780/7312499c-d2bc-11e5-9b41-13881d99391a.png)
