### PR TITLE
Add 16dp space in total between about_social and the border above it

### DIFF
--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -58,11 +58,11 @@
                     android:layout_marginLeft="@dimen/spacing_negative"
                     android:layout_marginRight="@dimen/spacing_negative"
                     android:layout_marginStart="@dimen/spacing_negative"
-                    android:layout_marginTop="@dimen/spacing"
-                    android:layout_marginBottom="@dimen/spacing_small"/>
+                    android:layout_marginTop="@dimen/spacing" />
 
                 <TextView
                     style="@style/AboutTitle"
+                    android:layout_marginTop="@dimen/spacing"
                     android:text="@string/about_social" />
 
                 <RelativeLayout

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -58,7 +58,8 @@
                     android:layout_marginLeft="@dimen/spacing_negative"
                     android:layout_marginRight="@dimen/spacing_negative"
                     android:layout_marginStart="@dimen/spacing_negative"
-                    android:layout_marginTop="@dimen/spacing" />
+                    android:layout_marginTop="@dimen/spacing"
+                    android:layout_marginBottom="@dimen/spacing_small"/>
 
                 <TextView
                     style="@style/AboutTitle"


### PR DESCRIPTION
Closes: #208 

I was going to modify the margin of @style/AboutTitle from 8dp to 16dp, but it was applied to the TextView with text value 'DroidKaigiについて' as well so I decided not to do so. Instead, I added margin bottom 8dp to have 16dp in total.

Below is the screen shot:

![device-2016-02-14-031849](https://cloud.githubusercontent.com/assets/920911/13029731/ade6c7b2-d2d7-11e5-8bd6-f0746640ae7b.png)
