### PR TITLE
Modified session detail description text is selectable

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -221,7 +221,8 @@
                     android:padding="@dimen/spacing"
                     android:textColor="@color/grey600"
                     android:textSize="@dimen/text"
-                    app:sessionDescription="@{session}" />
+                    app:sessionDescription="@{session}"
+                    android:textIsSelectable="true" />
 
                 <View
                     style="@style/Border"


### PR DESCRIPTION
I was going to modify the description text is selectable in session detail page.
However, text selectable is different look each os versions. 
How do you think?

Below is the screen shot:
Android 6
![anglermmb29qa1314502142016152153](https://cloud.githubusercontent.com/assets/4586632/13032287/b290a6c2-d32f-11e5-8a03-7d72215690b7.png)

Android 5
![shamulmy48ma1314502142016153106](https://cloud.githubusercontent.com/assets/4586632/13032303/170ba732-d330-11e5-8aa9-2f95494c6f18.png)

If you want to change select color or some selectable styles, please let me know.