### PR TITLE
Fixed detail page first visible position

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -97,6 +97,8 @@
                     android:drawablePadding="@dimen/icon_spacing"
                     android:drawableStart="@drawable/ic_access_time_grey_500_18dp"
                     android:ellipsize="end"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
                     android:lines="1"
                     android:padding="@dimen/spacing"
                     android:textColor="@color/grey500"


### PR DESCRIPTION
This is a bug from https://github.com/konifar/droidkaigi2016/pull/215.

When the user open SessionDetail page, the top area including tags and speaker is shown in the back of header.