### PR TITLE
Add VIBRATE permission for old JB devices.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:name=".MainApplication"


### PR DESCRIPTION
SecurityException occurs when this app notifies sessions on JB.
Add VIBRATE permission as a workaround.

FYR http://stackoverflow.com/questions/13602190/java-lang-securityexception-requires-vibrate-permission-on-jelly-bean-4-2

stacktrace on emulator(Galaxy Nexus API 16)
```
java.lang.RuntimeException: Unable to start receiver io.github.droidkaigi.confsched.receiver.SessionScheduleReceiver: java.lang.SecurityException: Requires VIBRATE permission
                                                     at android.app.ActivityThread.handleReceiver(ActivityThread.java:2236)
                                                     at android.app.ActivityThread.access$1500(ActivityThread.java:130)
                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1271)
                                                     at android.os.Handler.dispatchMessage(Handler.java:99)
                                                     at android.os.Looper.loop(Looper.java:137)
                                                     at android.app.ActivityThread.main(ActivityThread.java:4745)
                                                     at java.lang.reflect.Method.invokeNative(Native Method)
                                                     at java.lang.reflect.Method.invoke(Method.java:511)
                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
                                                     at dalvik.system.NativeStart.main(Native Method)
                                                  Caused by: java.lang.SecurityException: Requires VIBRATE permission
                                                     at android.os.Parcel.readException(Parcel.java:1425)
                                                     at android.os.Parcel.readException(Parcel.java:1379)
                                                     at android.app.INotificationManager$Stub$Proxy.enqueueNotificationWithTag(INotificationManager.java:295)
                                                     at android.app.NotificationManager.notify(NotificationManager.java:124)
                                                     at android.app.NotificationManager.notify(NotificationManager.java:103)
                                                     at io.github.droidkaigi.confsched.receiver.SessionScheduleReceiver.onReceive(SessionScheduleReceiver.java:60)
                                                     at android.app.ActivityThread.handleReceiver(ActivityThread.java:2229)
                                                     at android.app.ActivityThread.access$1500(ActivityThread.java:130) 
                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1271) 
                                                     at android.os.Handler.dispatchMessage(Handler.java:99) 
                                                     at android.os.Looper.loop(Looper.java:137) 
                                                     at android.app.ActivityThread.main(ActivityThread.java:4745) 
                                                     at java.lang.reflect.Method.invokeNative(Native Method) 
                                                     at java.lang.reflect.Method.invoke(Method.java:511) 
                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786) 
                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553) 
                                                     at dalvik.system.NativeStart.main(Native Method) 

```