### PR TITLE
Implemented  #206 - Favorite button doesn't return original scale

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/widget/CustomLikeButton.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/widget/CustomLikeButton.java
@@ -1,0 +1,31 @@
+package io.github.droidkaigi.confsched.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import com.like.LikeButton;
+
+public class CustomLikeButton extends LikeButton {
+
+    public CustomLikeButton(Context context) {
+        this(context, null);
+    }
+
+    public CustomLikeButton(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public CustomLikeButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            getParent().requestDisallowInterceptTouchEvent(true);
+        }
+        return super.onTouchEvent(event);
+    }
+
+}

--- a/app/src/main/res/layout/item_session.xml
+++ b/app/src/main/res/layout/item_session.xml
@@ -134,7 +134,7 @@
                     android:lines="1"
                     app:textRtlConsidered="@{session.speaker.name}" />
 
-                <com.like.LikeButton
+                <io.github.droidkaigi.confsched.widget.CustomLikeButton
                     android:id="@+id/btn_star"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
This issue’s cause is intercepted TouchEvent by RecyclerView.
(It occur not only LikeButton case.)

I implemented if LikeButton touched, parent not intercepted TouchEvent.

But develop a side effect.
When touch LikeButton and drag, not scroll parent RecyclerView.
If does not want this behavior, please reject PR.