### PR TITLE
Support Lollipop notification feature

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.fragment;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -59,6 +60,16 @@ public class SettingsFragment extends Fragment {
         binding.languageSettingsContainer.setOnClickListener(v -> showLanguagesDialog());
         binding.notificationSwitchRow.init(PrefUtil.KEY_NOTIFICATION_SETTING, true);
         binding.localTimeSwitchRow.init(PrefUtil.KEY_SHOW_LOCAL_TIME, false);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            binding.headsUpSwitchRow.init(PrefUtil.KEY_HEADS_UP_SETTING, true);
+            binding.headsUpSwitchRow.setVisibility(View.VISIBLE);
+            binding.headsUpBorder.setVisibility(View.VISIBLE);
+            binding.notificationSwitchRow.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                binding.headsUpSwitchRow.setEnabled(isChecked);
+                binding.headsUpSwitchRow.setChecked(isChecked);
+            });
+        }
     }
 
     private void showLanguagesDialog() {

--- a/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
@@ -45,6 +45,8 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
         String title = context.getResources().getQuantityString(
                 R.plurals.schedule_notification_title, REMIND_MINUTES, REMIND_MINUTES);
 
+        boolean headsUp = PrefUtil.get(context, PrefUtil.KEY_HEADS_UP_SETTING, true);
+
         Notification notification = new NotificationCompat.Builder(context)
                 .setContentIntent(pendingIntent)
                 .setSmallIcon(R.drawable.ic_access_time_grey_600_24dp)
@@ -53,7 +55,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
                 .setContentText(session.title)
                 .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setPriority(headsUp ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT)
                 .setCategory(NotificationCompat.CATEGORY_EVENT)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .build();

--- a/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
@@ -53,6 +53,9 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
                 .setContentText(session.title)
                 .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_EVENT)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .build();
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Service.NOTIFICATION_SERVICE);

--- a/app/src/main/java/io/github/droidkaigi/confsched/util/PrefUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/PrefUtil.java
@@ -10,6 +10,7 @@ public class PrefUtil {
 
     public static final String KEY_CURRENT_LANGUAGE_ID = "current_language_id";
     public static final String KEY_NOTIFICATION_SETTING = "notification_setting";
+    public static final String KEY_HEADS_UP_SETTING = "heads_up_setting";
     public static final String KEY_SHOW_LOCAL_TIME = "show_local_time";
 
     private static SharedPreferences pref;

--- a/app/src/main/java/io/github/droidkaigi/confsched/widget/SettingSwitchRowView.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/widget/SettingSwitchRowView.java
@@ -7,13 +7,15 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.widget.Checkable;
+import android.widget.CompoundButton;
 import android.widget.RelativeLayout;
 
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.databinding.ViewSettingSwitchRowBinding;
 import io.github.droidkaigi.confsched.util.PrefUtil;
 
-public class SettingSwitchRowView extends RelativeLayout {
+public class SettingSwitchRowView extends RelativeLayout implements Checkable {
 
     private static final String TAG = SettingSwitchRowView.class.getSimpleName();
 
@@ -73,4 +75,38 @@ public class SettingSwitchRowView extends RelativeLayout {
         }
     }
 
+    public void setOnCheckedChangeListener(CompoundButton.OnCheckedChangeListener listener) {
+        binding.settingSwitch.setOnCheckedChangeListener(listener);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        binding.getRoot().setEnabled(enabled);
+        binding.settingSwitch.setEnabled(enabled);
+        if (enabled) {
+            binding.settingTitle.setTextColor(getResources().getColor(R.color.black));
+            binding.settingDescription.setTextColor(getResources().getColor(R.color.grey600));
+        } else {
+            int disabledTextColor = getResources().getColor(R.color.black_alpha_30);
+            binding.settingTitle.setTextColor(disabledTextColor);
+            binding.settingDescription.setTextColor(disabledTextColor);
+        }
+    }
+
+    @Override
+    public void setChecked(boolean checked) {
+        setSetting(checked);
+        binding.settingSwitch.setChecked(checked);
+    }
+
+    @Override
+    public boolean isChecked() {
+        return binding.settingSwitch.isChecked();
+    }
+
+    @Override
+    public void toggle() {
+        switchSetting();
+    }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -67,6 +67,28 @@
         <View style="@style/Border" />
 
         <io.github.droidkaigi.confsched.widget.SettingSwitchRowView
+            android:id="@+id/local_time_switch_row"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:settingDescription="@string/settings_local_time_description"
+            app:settingTitle="@string/settings_local_time" />
+
+        <View style="@style/Border" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/spacing">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_notification_group"
+                android:textColor="?attr/colorPrimary"/>
+
+        </RelativeLayout>
+
+        <io.github.droidkaigi.confsched.widget.SettingSwitchRowView
             android:id="@+id/notification_switch_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -76,13 +98,14 @@
         <View style="@style/Border" />
 
         <io.github.droidkaigi.confsched.widget.SettingSwitchRowView
-            android:id="@+id/local_time_switch_row"
+            android:id="@+id/heads_up_switch_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:settingDescription="@string/settings_local_time_description"
-            app:settingTitle="@string/settings_local_time" />
+            android:visibility="gone"
+            app:settingDescription="@string/settings_heads_up_notification_description"
+            app:settingTitle="@string/settings_heads_up_notification" />
 
-        <View style="@style/Border" />
+        <View android:id="@+id/heads_up_border" style="@style/Border" android:visibility="gone" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -53,8 +53,11 @@
 
     <string name="settings_language">تعيين لغة</string>
     <string name="settings_language_description">يمكنك تغيير لغة العرض. بعد التغيير سيتم إعادة تشغيل التطبيق.</string>
+    <string name="settings_notification_group">إعلام</string>
     <string name="settings_notification">إعلام</string>
     <string name="settings_notification_description">اختيار ما إذا كان لتلقي التبليغ في هذا التطبيق .</string>
+    <string name="settings_heads_up_notification">إعلام رؤساء متابعة</string>
+    <string name="settings_heads_up_notification_description">اختيار ما إذا كنت تريد استخدام الإعلام رؤساء المتابعة.</string>
     <string name="settings_local_time">مرات العرض المحلية</string>
     <string name="settings_local_time_description">استخدام بالتوقيت المحلي الخاص بك بدلا من بالتوقيت المحلي للمؤتمر .</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -53,8 +53,11 @@
 
     <string name="settings_language">言語を設定</string>
     <string name="settings_language_description">表示言語を変更できます。変更後はアプリが再起動されます。</string>
+    <string name="settings_notification_group">通知</string>
     <string name="settings_notification">通知設定</string>
     <string name="settings_notification_description">通知を受け取るかどうかを設定できます。</string>
+    <string name="settings_heads_up_notification">ヘッドアップ通知</string>
+    <string name="settings_heads_up_notification_description">ヘッドアップ通知を使用するかどうかを設定できます。</string>
     <string name="settings_local_time">現地時間を表示</string>
     <string name="settings_local_time_description">チェックすると、セッションの時間はあなたのデバイスに設定された現地時間で表示されます。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,8 +65,11 @@
 
     <string name="settings_language">Change language</string>
     <string name="settings_language_description">Choose language in this app. After changed, app will restart.</string>
+    <string name="settings_notification_group">Notification</string>
     <string name="settings_notification">Notification</string>
     <string name="settings_notification_description">Choose whether to receive notification in this app.</string>
+    <string name="settings_heads_up_notification">Heads-up Notification</string>
+    <string name="settings_heads_up_notification_description">Choose whether to use Heads-up Notification.</string>
     <string name="settings_local_time">Show local times</string>
     <string name="settings_local_time_description">Use your local time instead of the conference\’s local time.</string>
 


### PR DESCRIPTION
Support below notification features:
- Add `category` for Priority-only mode
- Heads-up notification
  - Disable Heads-up notification on settings.
- Show on Lock-screen

----

Priority-only mode is available on Lollipop and above.
Android system filters interruption(Notification's sound and vibration) referring to the `category` in Priority mode.
So our app should set `category` to notifications.
https://developer.android.com/design/patterns/notifications.html#set_a_notification_category

----

Heads-up notification interrupts user's attention.
Even if users focus other, Users can notice favorite sessions.
<img src="https://cloud.githubusercontent.com/assets/500072/13035114/093ad9e2-d38b-11e5-8ee2-bf1813cb3f3c.png" width="320">

However, Heads-up notification is noisy.
So we add a setting to disable Heads-up notification.
This setting is hidden on Android 4.4 and below, because Heads-up notification is available on Lollipop and above.

Lollipop and above | KitKat and below
--------|--------
![sc_settings](https://cloud.githubusercontent.com/assets/500072/13035155/e0189756-d38b-11e5-8ebe-e0b2c38e0208.png) | ![sc_old-device](https://cloud.githubusercontent.com/assets/500072/13035160/1422a622-d38c-11e5-9f39-3ed5780736cf.png)

----

Users can confirm a session on lock screen.
<img src="https://cloud.githubusercontent.com/assets/500072/13035184/caba00e2-d38c-11e5-96b3-73646ddba0ae.png" width="320">

