### PR TITLE
Do not replace Switch's `onCheckedChangeListener` in SettingSwitchRowView

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/widget/SettingSwitchRowView.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/widget/SettingSwitchRowView.java
@@ -23,6 +23,8 @@ public class SettingSwitchRowView extends RelativeLayout implements Checkable {
 
     private String prefKey;
 
+    private CompoundButton.OnCheckedChangeListener onCheckedChangeListener;
+
     public SettingSwitchRowView(Context context) {
         this(context, null);
     }
@@ -45,7 +47,12 @@ public class SettingSwitchRowView extends RelativeLayout implements Checkable {
             binding.settingDescription.setText(description);
 
             binding.getRoot().setOnClickListener(v -> switchSetting());
-            binding.settingSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> setSetting(isChecked));
+            binding.settingSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                setSetting(isChecked);
+                if (onCheckedChangeListener != null) {
+                    onCheckedChangeListener.onCheckedChanged(buttonView, isChecked);
+                }
+            });
 
             a.recycle();
         }
@@ -76,7 +83,7 @@ public class SettingSwitchRowView extends RelativeLayout implements Checkable {
     }
 
     public void setOnCheckedChangeListener(CompoundButton.OnCheckedChangeListener listener) {
-        binding.settingSwitch.setOnCheckedChangeListener(listener);
+        onCheckedChangeListener = listener;
     }
 
     @Override


### PR DESCRIPTION
Added `setOnCheckedChangeListener` replaces necessary listener with new one.
This problem makes wrong behavior for SettingSwitchRowView.
This PR resolves the problem above.

Sorry. I made this problem at 1248e6aeef5c712b0d2de42e49c6cad253d8d077 in #228.