### PR TITLE
Added circular ripple effect to social icons on about page

### DIFF
--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -74,47 +74,49 @@
                 <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing">
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginLeft="@dimen/spacing_xsmall_negative"
+                    android:layout_marginStart="@dimen/spacing_xsmall_negative">
 
-                    <ImageView
-                        android:id="@+id/img_twitter"
-                        android:layout_width="@dimen/sns_icon_large"
-                        android:layout_height="@dimen/sns_icon_large"
-                        android:contentDescription="@string/icon"
-                        android:scaleType="centerCrop"
-                        android:src="@drawable/ic_twitter_40dp" />
-
-                    <View
+                    <FrameLayout
                         android:id="@+id/img_twitter_clicker"
-                        style="@style/ClickCover"
-                        android:layout_alignBottom="@id/img_twitter"
-                        android:layout_alignEnd="@id/img_twitter"
-                        android:layout_alignLeft="@id/img_twitter"
-                        android:layout_alignRight="@id/img_twitter"
-                        android:layout_alignStart="@id/img_twitter"
-                        android:layout_alignTop="@id/img_twitter" />
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/clickable_oval"
+                        android:padding="@dimen/spacing_xsmall"
+                        android:layout_toEndOf="@id/img_twitter_clicker"
+                        android:layout_toRightOf="@id/img_twitter_clicker">
 
-                    <ImageView
-                        android:id="@+id/img_facebook"
-                        android:layout_width="@dimen/sns_icon_large"
-                        android:layout_height="@dimen/sns_icon_large"
-                        android:layout_marginLeft="@dimen/spacing"
-                        android:layout_marginStart="@dimen/spacing"
-                        android:layout_toEndOf="@id/img_twitter"
-                        android:layout_toRightOf="@id/img_twitter"
-                        android:contentDescription="@string/icon"
-                        android:scaleType="centerCrop"
-                        android:src="@drawable/ic_facebook_40dp" />
+                        <ImageView
+                            android:id="@+id/img_twitter"
+                            android:layout_width="@dimen/sns_icon_large"
+                            android:layout_height="@dimen/sns_icon_large"
+                            android:contentDescription="@string/icon"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/ic_twitter_40dp" />
 
-                    <View
+                    </FrameLayout>
+
+                    <FrameLayout
                         android:id="@+id/img_facebook_clicker"
-                        style="@style/ClickCover"
-                        android:layout_alignBottom="@id/img_facebook"
-                        android:layout_alignEnd="@id/img_facebook"
-                        android:layout_alignLeft="@id/img_facebook"
-                        android:layout_alignRight="@id/img_facebook"
-                        android:layout_alignStart="@id/img_facebook"
-                        android:layout_alignTop="@id/img_facebook" />
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/spacing_small"
+                        android:layout_marginStart="@dimen/spacing_small"
+                        android:background="@drawable/clickable_oval"
+                        android:padding="@dimen/spacing_xsmall"
+                        android:layout_toEndOf="@id/img_twitter_clicker"
+                        android:layout_toRightOf="@id/img_twitter_clicker">
+
+                        <ImageView
+                            android:id="@+id/img_facebook"
+                            android:layout_width="@dimen/sns_icon_large"
+                            android:layout_height="@dimen/sns_icon_large"
+                            android:contentDescription="@string/icon"
+                            android:scaleType="centerCrop"
+                            android:src="@drawable/ic_facebook_40dp" />
+
+                    </FrameLayout>
 
                 </RelativeLayout>
 


### PR DESCRIPTION
Closes: #237 

## Done

I've added circular ripple effect to social icons on about page referencing `view_speaker_sns_icons.xml`.

## One note

I've realized that in `view_speaker_sns_icons.xml`, `RelativeLayout` is used for achieving the ripple effects, which is great, but I thought `FrameLayout` can be used in this case as no `RelativeLayout` attribute is used in the child views. Since `FrameLayout` is less costly than `RelativeLayout` in terms of performance (in my understanding..), I've decided to use `FrameLayout` in my pull request.

If replacing `RelativeLayout` with `FrameLayout` for `view_speaker_sns_icons.xml` is considered as appropriate, I'd like to add that replacement in this PR as well. 

What do you think? 

Corresponding code: https://github.com/konifar/droidkaigi2016/blob/2e382c6b9f1dfe95867b0d5ab61704d0ec8d4021/app/src/main/res/layout/view_speaker_sns_icons.xml#L18-L55

## How it looks

![bullheadmmb29qa1347002152016231844](https://cloud.githubusercontent.com/assets/920911/13051066/91bed840-d43a-11e5-869d-4e74b3643d5c.gif)

