### PR TITLE
Modified not to show loading view on fetch and save data

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsFragment.java
@@ -117,7 +117,6 @@ public class SessionsFragment extends Fragment implements StackedPageListener {
     }
 
     private Subscription fetchAndSave() {
-        showLoadingView();
         return client.getSessions(LocaleUtil.getCurrentLanguageId(getActivity()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())


### PR DESCRIPTION
Closes: #239 

## Done

I've modified not to show loading view on fetch and save data. While loading data, the loading view still shows and it will dismiss when loading is finished.

## Looks like this:

![bullheadmmb29qa1347002162016022424](https://cloud.githubusercontent.com/assets/920911/13055761/85dad5f0-d454-11e5-9060-9d9720899af1.gif)
