### PR TITLE
Increase maximum number of contributors can be displayed from 30 to 100.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/api/DroidKaigiClient.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/api/DroidKaigiClient.java
@@ -115,7 +115,7 @@ public class DroidKaigiClient {
     }
 
     public interface GithubService {
-        @GET("/repos/{owner}/{repo}/contributors")
+        @GET("/repos/{owner}/{repo}/contributors?per_page=100")
         Observable<List<Contributor>> getContributors(@Path("owner") String owner, @Path("repo") String repo);
     }
 }


### PR DESCRIPTION
Response from GitHub API is paginated to 30 items by default. I increased it to 100 (this is maximum)
[GitHub API v3 | GitHub Developer Guide](https://developer.github.com/v3/#pagination)

**Before**
![before_50](https://cloud.githubusercontent.com/assets/819673/13072403/7db345b4-d4dc-11e5-82ce-b2a34169f6e1.png)

**After**
![after_50](https://cloud.githubusercontent.com/assets/819673/13072405/7f738990-d4dc-11e5-8206-e24b75c25d15.png)