### PR TITLE
Fix in-app locale being reset on orientation change

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.activity;
 import android.app.Activity;
 import android.app.Notification;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.databinding.DataBindingUtil;
 import android.os.Build;
 import android.os.Bundle;
@@ -55,6 +56,12 @@ public class MainActivity extends AppCompatActivity
         intent.putExtra(EXTRA_SHOULD_REFRESH, shouldRefresh);
         activity.startActivity(intent);
         activity.overridePendingTransition(R.anim.activity_fade_enter, R.anim.activity_fade_exit);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        LocaleUtil.initLocale(this);
     }
 
     @Override


### PR DESCRIPTION
Orientation change causes broken layout and string.

![screenshot_20160218-151710](https://cloud.githubusercontent.com/assets/400558/13135336/f77bd6fa-d652-11e5-98cf-67d225b3c73b.png)

Special thanks to @ichigotake ..!!!