### PR TITLE
abortOnError true

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,6 @@ android {
     }
 
     lintOptions {
-        abortOnError false
         disable 'InvalidPackage'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,11 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'me.tatarka:gradle-retrolambda:3.2.3'
+        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'io.fabric.tools:gradle:1.21.2'
     }
+
+    configurations.classpath.exclude group: 'com.android.tools.external.lombok'
 }
 
 allprojects {


### PR DESCRIPTION
* Use android-retrolambda-lombok.
    * our company has achievement in production.
* `abortOnError false` removed, because 'Error' rules may terminate the app.