### PR TITLE
Use custom scopes appropriately

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/MainApplication.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/MainApplication.java
@@ -2,42 +2,19 @@ package io.github.droidkaigi.confsched;
 
 import android.app.Application;
 import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatActivity;
 
 import com.crashlytics.android.Crashlytics;
 import com.jakewharton.threetenabp.AndroidThreeTen;
 
 import io.fabric.sdk.android.Fabric;
 import io.github.droidkaigi.StethoWrapper;
-import io.github.droidkaigi.confsched.di.ActivityComponent;
-import io.github.droidkaigi.confsched.di.ActivityModule;
 import io.github.droidkaigi.confsched.di.AppComponent;
 import io.github.droidkaigi.confsched.di.AppModule;
 import io.github.droidkaigi.confsched.di.DaggerAppComponent;
-import io.github.droidkaigi.confsched.di.FragmentComponent;
-import io.github.droidkaigi.confsched.di.FragmentModule;
 
 public class MainApplication extends Application {
 
     AppComponent appComponent;
-
-    @NonNull
-    public static FragmentComponent getComponent(Fragment fragment) {
-        assert fragment.getActivity() != null;
-        AppCompatActivity activity = (AppCompatActivity) fragment.getActivity();
-        MainApplication application = (MainApplication) fragment.getContext().getApplicationContext();
-        return application.appComponent
-                .plus(new ActivityModule(activity))
-                .plus(new FragmentModule(fragment));
-    }
-
-    @NonNull
-    public static ActivityComponent getComponent(AppCompatActivity activity) {
-        MainApplication application = (MainApplication) activity.getApplicationContext();
-        return application.appComponent
-                .plus(new ActivityModule(activity));
-    }
 
     @NonNull
     public AppComponent getComponent() {

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/BaseActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/BaseActivity.java
@@ -7,7 +7,7 @@ import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.di.ActivityComponent;
 import io.github.droidkaigi.confsched.di.ActivityModule;
 
-public class BaseActivity extends AppCompatActivity {
+public abstract class BaseActivity extends AppCompatActivity {
 
     private ActivityComponent activityComponent;
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/BaseActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/BaseActivity.java
@@ -1,0 +1,22 @@
+package io.github.droidkaigi.confsched.activity;
+
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+
+import io.github.droidkaigi.confsched.MainApplication;
+import io.github.droidkaigi.confsched.di.ActivityComponent;
+import io.github.droidkaigi.confsched.di.ActivityModule;
+
+public class BaseActivity extends AppCompatActivity {
+
+    private ActivityComponent activityComponent;
+
+    @NonNull
+    public ActivityComponent getComponent() {
+        if (activityComponent == null) {
+            MainApplication mainApplication = (MainApplication) getApplication();
+            activityComponent = mainApplication.getComponent().plus(new ActivityModule(this));
+        }
+        return activityComponent;
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/ContributorsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/ContributorsActivity.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.util.Log;
 import android.view.MenuItem;
@@ -20,7 +19,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.api.DroidKaigiClient;
 import io.github.droidkaigi.confsched.dao.ContributorDao;
@@ -37,7 +35,7 @@ import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
-public class ContributorsActivity extends AppCompatActivity {
+public class ContributorsActivity extends BaseActivity {
 
     public static final String TAG = ContributorsActivity.class.getSimpleName();
 
@@ -63,7 +61,7 @@ public class ContributorsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_contributors);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
         initToolbar();
         binding.recyclerView.addItemDecoration(new DividerItemDecoration(getApplicationContext(), R.drawable.border_small));
         binding.recyclerView.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/MainActivity.java
@@ -16,12 +16,10 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.GravityCompat;
 import android.support.v7.app.ActionBarDrawerToggle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.databinding.ActivityMainBinding;
 import io.github.droidkaigi.confsched.fragment.SessionsFragment;
@@ -34,7 +32,7 @@ import io.github.droidkaigi.confsched.util.AppUtil;
 import io.github.droidkaigi.confsched.util.LocaleUtil;
 import rx.subscriptions.CompositeSubscription;
 
-public class MainActivity extends AppCompatActivity
+public class MainActivity extends BaseActivity
         implements NavigationView.OnNavigationItemSelectedListener, FragmentManager.OnBackStackChangedListener {
 
     private static final String EXTRA_SHOULD_REFRESH = "should_refresh";
@@ -76,7 +74,7 @@ public class MainActivity extends AppCompatActivity
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main);
         DataBindingUtil.bind(binding.navView.getHeaderView(0));
 
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
 
         subscription.add(brokerProvider.get().observe().subscribe(page -> {
             toggleToolbarElevation(page.shouldToggleToolbar());

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/SearchActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/SearchActivity.java
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched.activity;
 
-import org.parceler.Parcels;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -13,7 +11,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.text.Editable;
 import android.text.Spannable;
@@ -28,12 +25,13 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.TextView;
 
+import org.parceler.Parcels;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.dao.CategoryDao;
 import io.github.droidkaigi.confsched.dao.PlaceDao;
@@ -49,7 +47,7 @@ import io.github.droidkaigi.confsched.widget.BindingHolder;
 import io.github.droidkaigi.confsched.widget.itemdecoration.DividerItemDecoration;
 import rx.Observable;
 
-public class SearchActivity extends AppCompatActivity implements TextWatcher {
+public class SearchActivity extends BaseActivity implements TextWatcher {
 
     public static final String RESULT_STATUS_CHANGED_SESSIONS = "statusChangedSessions";
     private static final int REQ_DETAIL = 1;
@@ -82,7 +80,7 @@ public class SearchActivity extends AppCompatActivity implements TextWatcher {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_search);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
 
         initToolbar();
         initRecyclerView();

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/SearchedSessionsActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/SearchedSessionsActivity.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import org.parceler.Parcels;
@@ -19,7 +18,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.dao.SessionDao;
 import io.github.droidkaigi.confsched.databinding.ActivitySearchedSessionsBinding;
@@ -30,7 +28,7 @@ import io.github.droidkaigi.confsched.model.Session;
 import io.github.droidkaigi.confsched.util.AnalyticsTracker;
 import io.github.droidkaigi.confsched.util.AppUtil;
 
-public class SearchedSessionsActivity extends AppCompatActivity implements SessionsFragment.OnChangeSessionListener {
+public class SearchedSessionsActivity extends BaseActivity implements SessionsFragment.OnChangeSessionListener {
 
     @Inject
     AnalyticsTracker analyticsTracker;
@@ -51,7 +49,7 @@ public class SearchedSessionsActivity extends AppCompatActivity implements Sessi
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, R.layout.activity_searched_sessions);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
 
         SearchGroup searchGroup = Parcels.unwrap(getIntent().getParcelableExtra(SearchGroup.class.getSimpleName()));
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionDetailActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionDetailActivity.java
@@ -8,20 +8,18 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import org.parceler.Parcels;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.fragment.SessionDetailFragment;
 import io.github.droidkaigi.confsched.model.Session;
 import io.github.droidkaigi.confsched.util.AnalyticsTracker;
 
-public class SessionDetailActivity extends AppCompatActivity {
+public class SessionDetailActivity extends BaseActivity {
 
     @Inject
     AnalyticsTracker analyticsTracker;
@@ -46,7 +44,7 @@ public class SessionDetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         DataBindingUtil.setContentView(this, R.layout.activity_session_detail);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
 
         Session session = Parcels.unwrap(getIntent().getParcelableExtra(Session.class.getSimpleName()));
         replaceFragment(SessionDetailFragment.create(session));

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionFeedbackActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/SessionFeedbackActivity.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
@@ -21,7 +20,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.api.DroidKaigiClient;
 import io.github.droidkaigi.confsched.databinding.ActivitySessionFeedbackBinding;
@@ -32,7 +30,7 @@ import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
-public class SessionFeedbackActivity extends AppCompatActivity {
+public class SessionFeedbackActivity extends BaseActivity {
     private static final String TAG = SessionFeedbackActivity.class.getName();
     private ActivitySessionFeedbackBinding binding;
     private Session session;
@@ -56,7 +54,7 @@ public class SessionFeedbackActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_session_feedback);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
         session = Parcels.unwrap(getIntent().getParcelableExtra(Session.class.getSimpleName()));
 
         initToolbar(session.title);

--- a/app/src/main/java/io/github/droidkaigi/confsched/activity/WebViewActivity.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/activity/WebViewActivity.java
@@ -6,7 +6,6 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.webkit.WebView;
@@ -16,7 +15,7 @@ import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.databinding.ActivityWebViewBinding;
 import io.github.droidkaigi.confsched.util.AppUtil;
 
-public class WebViewActivity extends AppCompatActivity {
+public class WebViewActivity extends BaseActivity {
 
     private static final String EXTRA_URL = "url";
     private static final String EXTRA_TITLE = "title";

--- a/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
@@ -1,12 +1,12 @@
 package io.github.droidkaigi.confsched.di;
 
-import com.google.android.gms.analytics.GoogleAnalytics;
-import com.google.android.gms.analytics.Tracker;
-
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
+
+import com.google.android.gms.analytics.GoogleAnalytics;
+import com.google.android.gms.analytics.Tracker;
 
 import java.io.File;
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/AboutFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/AboutFragment.java
@@ -3,14 +3,12 @@ package io.github.droidkaigi.confsched.fragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.activity.ContributorsActivity;
@@ -18,7 +16,7 @@ import io.github.droidkaigi.confsched.databinding.FragmentAboutBinding;
 import io.github.droidkaigi.confsched.util.AppUtil;
 import io.github.droidkaigi.confsched.util.LocaleUtil;
 
-public class AboutFragment extends Fragment {
+public class AboutFragment extends BaseFragment {
 
     private static final String REP_TWITTER_NAME = "mhidaka";
     private static final String CONF_TWITTER_NAME = "DroidKaigi";
@@ -46,7 +44,7 @@ public class AboutFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
     }
 
     private void initView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/BaseFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/BaseFragment.java
@@ -8,7 +8,7 @@ import io.github.droidkaigi.confsched.activity.BaseActivity;
 import io.github.droidkaigi.confsched.di.FragmentComponent;
 import io.github.droidkaigi.confsched.di.FragmentModule;
 
-public class BaseFragment extends Fragment {
+public abstract class BaseFragment extends Fragment {
 
     private FragmentComponent fragmentComponent;
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/BaseFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/BaseFragment.java
@@ -1,0 +1,30 @@
+package io.github.droidkaigi.confsched.fragment;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+
+import io.github.droidkaigi.confsched.activity.BaseActivity;
+import io.github.droidkaigi.confsched.di.FragmentComponent;
+import io.github.droidkaigi.confsched.di.FragmentModule;
+
+public class BaseFragment extends Fragment {
+
+    private FragmentComponent fragmentComponent;
+
+    @NonNull
+    public FragmentComponent getComponent() {
+        if (fragmentComponent != null) {
+            return fragmentComponent;
+        }
+
+        Activity activity = getActivity();
+        if (!(activity instanceof BaseActivity)) {
+            throw new IllegalStateException(
+                    "The activity of this fragment is not an instance of BaseActivity");
+        }
+        fragmentComponent = ((BaseActivity) activity).getComponent()
+                .plus(new FragmentModule(this));
+        return fragmentComponent;
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/MapFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/MapFragment.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AlertDialog;
@@ -45,7 +44,7 @@ import rx.Observable;
 import static io.github.droidkaigi.confsched.fragment.MapFragmentPermissionsDispatcher.initGoogleMapWithCheck;
 
 @RuntimePermissions
-public class MapFragment extends Fragment {
+public class MapFragment extends BaseFragment {
 
     public static final LatLng LAT_LNG_CENTER = new LatLng(35.604757, 139.683788);
     private static final int DEFAULT_ZOOM = 17;

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionDetailFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionDetailFragment.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -23,7 +22,6 @@ import org.parceler.Parcels;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.dao.SessionDao;
@@ -33,7 +31,7 @@ import io.github.droidkaigi.confsched.util.AlarmUtil;
 import io.github.droidkaigi.confsched.util.AppUtil;
 import io.github.droidkaigi.confsched.util.IntentUtil;
 
-public class SessionDetailFragment extends Fragment {
+public class SessionDetailFragment extends BaseFragment {
 
     @Inject
     SessionDao dao;
@@ -107,7 +105,7 @@ public class SessionDetailFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
     }
 
     @Override

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsFragment.java
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched.fragment;
 
-import org.parceler.Parcels;
-
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -21,6 +19,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.parceler.Parcels;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +28,6 @@ import java.util.TreeMap;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.activity.SearchActivity;
@@ -46,7 +45,7 @@ import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
-public class SessionsFragment extends Fragment implements StackedPageListener {
+public class SessionsFragment extends BaseFragment implements StackedPageListener {
 
     public static final String TAG = SessionsFragment.class.getSimpleName();
     private static final String ARG_SHOULD_REFRESH = "should_refresh";
@@ -100,7 +99,7 @@ public class SessionsFragment extends Fragment implements StackedPageListener {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
         if (context instanceof OnChangeSessionListener) {
             onChangeSessionListener = (OnChangeSessionListener) context;
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsTabFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SessionsTabFragment.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -22,7 +21,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.dao.SessionDao;
@@ -34,7 +32,7 @@ import io.github.droidkaigi.confsched.widget.ArrayRecyclerAdapter;
 import io.github.droidkaigi.confsched.widget.BindingHolder;
 import io.github.droidkaigi.confsched.widget.itemdecoration.SpaceItemDecoration;
 
-public class SessionsTabFragment extends Fragment {
+public class SessionsTabFragment extends BaseFragment {
 
     protected static final String ARG_SESSIONS = "sessions";
     private static final int REQ_DETAIL = 1;
@@ -69,7 +67,7 @@ public class SessionsTabFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
         if (context instanceof SessionsFragment.OnChangeSessionListener) {
             onChangeSessionListener = (SessionsFragment.OnChangeSessionListener) context;
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -17,7 +16,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.dao.SessionDao;
@@ -26,7 +24,7 @@ import io.github.droidkaigi.confsched.prefs.DefaultPrefsSchema;
 import io.github.droidkaigi.confsched.util.LocaleUtil;
 import rx.Observable;
 
-public class SettingsFragment extends Fragment {
+public class SettingsFragment extends BaseFragment {
 
     public static final String TAG = SettingsFragment.class.getSimpleName();
 
@@ -52,7 +50,7 @@ public class SettingsFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
     }
 
     private void initView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SponsorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SponsorsFragment.java
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched.fragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,7 +12,6 @@ import org.apmem.tools.layouts.FlowLayout;
 
 import javax.inject.Inject;
 
-import io.github.droidkaigi.confsched.MainApplication;
 import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.databinding.FragmentSponsorsBinding;
 import io.github.droidkaigi.confsched.model.Sponsor;
@@ -22,7 +20,7 @@ import io.github.droidkaigi.confsched.util.AppUtil;
 import io.github.droidkaigi.confsched.widget.SponsorImageView;
 import rx.Observable;
 
-public class SponsorsFragment extends Fragment {
+public class SponsorsFragment extends BaseFragment {
 
     private FragmentSponsorsBinding binding;
 
@@ -44,7 +42,7 @@ public class SponsorsFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        MainApplication.getComponent(this).inject(this);
+        getComponent().inject(this);
     }
 
     private void initView() {


### PR DESCRIPTION
The activity has to retain the reference of its component.
If you instantiate ActivityModule every time on the call of MainApplication::getComponent(), the scope will be broken; each child fragment has activity-scoped instances **separately** despite their life cycle should be tied to their activity.
Actually the custom scopes are not needed in this app and that's why there are no bugs related to them. So this PR is some kind of a reference.