### PR TITLE
Fix #318, crashes in Orma migration engines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,8 +146,8 @@ dependencies {
     compile "org.parceler:parceler-api:1.0.4"
     apt "org.parceler:parceler:1.0.4"
 
-    apt 'com.github.gfx.android.orma:orma-processor:2.0.5'
-    compile 'com.github.gfx.android.orma:orma:2.0.5'
+    apt 'com.github.gfx.android.orma:orma-processor:2.0.6'
+    compile 'com.github.gfx.android.orma:orma:2.0.6'
     compile 'com.github.hotchemi:permissionsdispatcher:2.0.7'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.0.7'
 


### PR DESCRIPTION
Fixed at Orma v2.0.6, which includes https://github.com/gfx/Android-Orma/pull/193

Please :sob: 