### PR TITLE
Set accent color to notifications.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 
 import org.parceler.Parcels;
 
@@ -58,6 +59,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
                 .setPriority(headsUp ? NotificationCompat.PRIORITY_HIGH : NotificationCompat.PRIORITY_DEFAULT)
                 .setCategory(NotificationCompat.CATEGORY_EVENT)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setColor(ContextCompat.getColor(context, R.color.theme500))
                 .build();
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Service.NOTIFICATION_SERVICE);


### PR DESCRIPTION
Set accent color to notification icon(small icon) to get user's attention.
This feature is available on Lollipop and above.

----

![colored_notification](https://cloud.githubusercontent.com/assets/500072/13327445/364d88e4-dc2d-11e5-974a-111f14413dd0.png)