### PR TITLE
Update kvs-schema version to 3.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,8 +151,8 @@ dependencies {
     compile 'com.github.hotchemi:permissionsdispatcher:2.0.7'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.0.7'
 
-    compile 'com.github.rejasupotaro.kvs-schema:library:2.0.0'
-    apt 'com.github.rejasupotaro.kvs-schema:compiler:2.0.0'
+    compile 'com.github.rejasupotaro.kvs-schema:library:3.0.0'
+    apt 'com.github.rejasupotaro.kvs-schema:compiler:3.0.0'
 
     compile "com.squareup.picasso:picasso:2.5.2"
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
@@ -20,7 +20,7 @@ import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.ActivityNavigator;
 import io.github.droidkaigi.confsched.dao.SessionDao;
 import io.github.droidkaigi.confsched.databinding.FragmentSettingsBinding;
-import io.github.droidkaigi.confsched.prefs.DefaultPrefsSchema;
+import io.github.droidkaigi.confsched.prefs.DefaultPrefs;
 import io.github.droidkaigi.confsched.util.LocaleUtil;
 import rx.Observable;
 
@@ -57,22 +57,22 @@ public class SettingsFragment extends BaseFragment {
         binding.txtLanguage.setText(LocaleUtil.getCurrentLanguage(getActivity()));
         binding.languageSettingsContainer.setOnClickListener(v -> showLanguagesDialog());
 
-        boolean shouldNotify = DefaultPrefsSchema.get(getContext()).getNotificationFlag(true);
+        boolean shouldNotify = DefaultPrefs.get(getContext()).getNotificationFlag(true);
         binding.notificationSwitchRow.init(shouldNotify, ((v, isChecked) -> {
-            DefaultPrefsSchema.get(getContext()).putNotificationFlag(isChecked);
+            DefaultPrefs.get(getContext()).putNotificationFlag(isChecked);
             binding.headsUpSwitchRow.setEnabled(isChecked);
         }));
         binding.headsUpSwitchRow.setEnabled(shouldNotify);
 
-        boolean shouldShowLocalTime = DefaultPrefsSchema.get(getContext()).getShowLocalTimeFlag(false);
+        boolean shouldShowLocalTime = DefaultPrefs.get(getContext()).getShowLocalTimeFlag(false);
         binding.localTimeSwitchRow.init(shouldShowLocalTime, ((buttonView, isChecked) -> {
-            DefaultPrefsSchema.get(getContext()).putShowLocalTimeFlag(isChecked);
+            DefaultPrefs.get(getContext()).putShowLocalTimeFlag(isChecked);
         }));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            boolean headsUp = DefaultPrefsSchema.get(getContext()).getHeadsUpFlag(true);
+            boolean headsUp = DefaultPrefs.get(getContext()).getHeadsUpFlag(true);
             binding.headsUpSwitchRow.init(headsUp, (v, isChecked) -> {
-                DefaultPrefsSchema.get(getContext()).putHeadsUpFlag(isChecked);
+                DefaultPrefs.get(getContext()).putHeadsUpFlag(isChecked);
             });
             binding.headsUpSwitchRow.setVisibility(View.VISIBLE);
             binding.headsUpBorder.setVisibility(View.VISIBLE);

--- a/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
@@ -1,11 +1,9 @@
 package io.github.droidkaigi.confsched.prefs;
 
-import android.content.Context;
-
 import com.rejasupotaro.android.kvs.annotations.Key;
 import com.rejasupotaro.android.kvs.annotations.Table;
 
-@Table("io.github.droidkaigi.confsched_preferences")
+@Table(name = "io.github.droidkaigi.confsched_preferences")
 public abstract class DefaultPrefsSchema {
     @Key("current_language_id")
     String languageId;
@@ -15,13 +13,4 @@ public abstract class DefaultPrefsSchema {
     boolean headsUpFlag;
     @Key("show_local_time")
     boolean showLocalTimeFlag;
-
-    private static DefaultPrefs prefs;
-
-    public static synchronized DefaultPrefs get(Context context) {
-        if (prefs == null) {
-            prefs = new DefaultPrefs(context);
-        }
-        return prefs;
-    }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
@@ -18,7 +18,7 @@ import io.github.droidkaigi.confsched.R;
 import io.github.droidkaigi.confsched.activity.MainActivity;
 import io.github.droidkaigi.confsched.activity.SessionDetailActivity;
 import io.github.droidkaigi.confsched.model.Session;
-import io.github.droidkaigi.confsched.prefs.DefaultPrefsSchema;
+import io.github.droidkaigi.confsched.prefs.DefaultPrefs;
 
 public class SessionScheduleReceiver extends BroadcastReceiver {
 
@@ -26,7 +26,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        boolean shouldNotify = DefaultPrefsSchema.get(context).getNotificationFlag(true);
+        boolean shouldNotify = DefaultPrefs.get(context).getNotificationFlag(true);
         if (!shouldNotify) {
             return;
         }
@@ -46,7 +46,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
         String title = context.getResources().getQuantityString(
                 R.plurals.schedule_notification_title, REMIND_MINUTES, REMIND_MINUTES);
 
-        boolean headsUp = DefaultPrefsSchema.get(context).getHeadsUpFlag(true);
+        boolean headsUp = DefaultPrefs.get(context).getHeadsUpFlag(true);
 
         Notification notification = new NotificationCompat.Builder(context)
                 .setContentIntent(pendingIntent)

--- a/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
@@ -17,7 +17,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import io.github.droidkaigi.confsched.BuildConfig;
-import io.github.droidkaigi.confsched.prefs.DefaultPrefsSchema;
+import io.github.droidkaigi.confsched.prefs.DefaultPrefs;
 
 public class LocaleUtil {
 
@@ -62,7 +62,7 @@ public class LocaleUtil {
 
     public static void setLocale(Context context, @NonNull String languageId) {
         Configuration config = new Configuration();
-        DefaultPrefsSchema.get(context).putLanguageId(languageId);
+        DefaultPrefs.get(context).putLanguageId(languageId);
         Locale locale = new Locale(languageId);
         Locale.setDefault(locale);
         config.locale = locale;
@@ -70,7 +70,7 @@ public class LocaleUtil {
     }
 
     public static String getCurrentLanguageId(Context context) {
-        String languageId = DefaultPrefsSchema.get(context).getLanguageId();
+        String languageId = DefaultPrefs.get(context).getLanguageId();
         try {
             if (TextUtils.isEmpty(languageId)) {
                 languageId = Locale.getDefault().getLanguage().toLowerCase();
@@ -125,7 +125,7 @@ public class LocaleUtil {
 
     public static TimeZone getDisplayTimeZone(Context context) {
         TimeZone defaultTimeZone = TimeZone.getDefault();
-        boolean shouldShowLocalTime = DefaultPrefsSchema.get(context).getShowLocalTimeFlag(false);
+        boolean shouldShowLocalTime = DefaultPrefs.get(context).getShowLocalTimeFlag(false);
         return (shouldShowLocalTime && defaultTimeZone != null) ? defaultTimeZone : CONFERENCE_TIMEZONE;
     }
 


### PR DESCRIPTION
# Overview

I updated kvs-schema version. This diff is

* Generate initialize method in compile time
* Enable to specify builder class

This change makes schema class simple :smile: 

```java
@Table(name = "io.github.droidkaigi.confsched_preferences")
public abstract class DefaultPrefsSchema {
    @Key("current_language_id")
    String languageId;
    @Key("notification_setting")
    boolean notificationFlag;
    @Key("heads_up_setting")
    boolean headsUpFlag;
    @Key("show_local_time")
    boolean showLocalTimeFlag;
}
```

# Detail

Previously, we need to write singleton code manually. To reduce boilerplate code, I updated the library to generate initialize method.

```
@Table(name = "io.github.droidkaigi.confsched_preferences")
 public abstract class DefaultPrefsSchema {
     ...
-
-    private static DefaultPrefs prefs;
-
-    public static synchronized DefaultPrefs get(Context context) {
-        if (prefs == null) {
-            prefs = new DefaultPrefs(context);
-        }
-        return prefs;
-    }
 }
```

Actual generated code is below.

```java
public final class DefaultPrefs extends PrefsSchema {

  private static DefaultPrefs singleton;

  public static DefaultPrefs get(Context context) {
    if (singleton != null) return singleton;
    synchronized (DefaultPrefs.class) { if (singleton == null) singleton = new DefaultPrefs(context); };
    return singleton;
  }
```

We can get a singleton instance of DefaultPrefs by `DefaultPrefs.get` directly.

In addition, from 3.0.0, we can specify builder class by `@Table(builder = *.class)` for DefaultPrefs to change creation mode or use custom SharedPreferences. But it is for special case. We don't have to specify builder class at least in this project.

# Related links

- [Create initialize methods in a compile time · Issue #10 · rejasupotaro/kvs-schema](https://github.com/rejasupotaro/kvs-schema/issues/10)
- [Generate initialize methods in compile time by rejasupotaro · Pull Request #11 · rejasupotaro/kvs-schema](https://github.com/rejasupotaro/kvs-schema/pull/11)
- [Enable to specify builder class by rejasupotaro · Pull Request #12 · rejasupotaro/kvs-schema](https://github.com/rejasupotaro/kvs-schema/pull/12)