### PR TITLE
Fix test class names

### DIFF
--- a/app/src/androidTest/java/io/github/droidkaigi/confsched/util/AppUtilTest.java
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched/util/AppUtilTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(AndroidJUnit4.class)
-public class AppUtilsTest {
+public class AppUtilTest {
 
     @Test
     public void testTwitterUrl() throws Exception {

--- a/app/src/androidTest/java/io/github/droidkaigi/confsched/util/LocaleUtilTest.java
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched/util/LocaleUtilTest.java
@@ -15,7 +15,7 @@ import io.github.droidkaigi.confsched.prefs.DefaultPrefs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(AndroidJUnit4.class)
-public class LocaleUtilsTest {
+public class LocaleUtilTest {
 
     @Test
     public void testCurrentLanguageId() throws Exception {

--- a/app/src/androidTest/java/io/github/droidkaigi/confsched/util/LocaleUtilsTest.java
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched/util/LocaleUtilsTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.Locale;
 
-import io.github.droidkaigi.confsched.prefs.DefaultPrefsSchema;
+import io.github.droidkaigi.confsched.prefs.DefaultPrefs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,11 +23,11 @@ public class LocaleUtilsTest {
         // is not null value.
         assertThat(LocaleUtil.getCurrentLanguageId(context)).isNotNull();
 
-        DefaultPrefsSchema.get(context).putLanguageId("ja");
+        DefaultPrefs.get(context).putLanguageId("ja");
         // eq to languageID is put in SharedPreferences.
         assertThat(LocaleUtil.getCurrentLanguageId(context)).isEqualTo("ja");
 
-        DefaultPrefsSchema.get(context).removeLanguageId();
+        DefaultPrefs.get(context).removeLanguageId();
         String defaultLanguage = Locale.getDefault().getLanguage().toLowerCase();
         if (Arrays.asList(LocaleUtil.SUPPORT_LANG).contains(defaultLanguage)) {
             // eq to Locale.getDefault().getLanguage() when it is supported


### PR DESCRIPTION
Do you the unit test has been successful?
I got this error.

```
LocaleUtilsTest.java
Error:(26, 27) エラー: シンボルを見つけられません
シンボル:   メソッド get(Context)
場所: クラス DefaultPrefsSchema
Error:(30, 27) エラー: シンボルを見つけられません
シンボル:   メソッド get(Context)
場所: クラス DefaultPrefsSchema
エラー2個
:app:compileRetrolambdaDevelopDebugAndroidTest
Error:Execution failed for task ':app:compileDevelopDebugAndroidTestJavaWithJavac'.
> Compilation failed; see the compiler error output for details.
Information:BUILD FAILED
```


I presume you forgot to rename the test class of kvs-schema at the time of [this commit](https://github.com/konifar/droidkaigi2016/commit/5f1b44806b1dc68c3dcbbd6b4a76d26fe994235d).

And it seems to have also forgotten to rename these test files name at the time of [this commit](https://github.com/konifar/droidkaigi2016/commit/6b21f44aca8685ec7a92cc17911f6283bfcf730e).
I renamed those in passing:)

(I'm sorry if my interpretation is mistaken...)

Please confirm the above! :wink:
