### PR TITLE
Update KVS Schema and utilize a new feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -157,8 +157,8 @@ dependencies {
     compile 'com.github.hotchemi:permissionsdispatcher:2.0.7'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.0.7'
 
-    compile 'com.github.rejasupotaro.kvs-schema:library:3.0.0'
-    apt 'com.github.rejasupotaro.kvs-schema:compiler:3.0.0'
+    compile 'com.rejasupotaro:kvs-schema:5.0.0'
+    apt 'com.rejasupotaro:kvs-schema-compiler:5.0.0'
 
     compile "com.squareup.picasso:picasso:2.5.2"
     compile 'com.squareup.retrofit2:retrofit:2.0.0'

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
@@ -57,22 +57,23 @@ public class SettingsFragment extends BaseFragment {
         binding.txtLanguage.setText(LocaleUtil.getCurrentLanguage(getActivity()));
         binding.languageSettingsContainer.setOnClickListener(v -> showLanguagesDialog());
 
-        boolean shouldNotify = DefaultPrefs.get(getContext()).getNotificationFlag(true);
+        DefaultPrefs prefs = DefaultPrefs.get(getContext());
+
+        boolean shouldNotify = prefs.getNotificationFlag();
         binding.notificationSwitchRow.init(shouldNotify, ((v, isChecked) -> {
-            DefaultPrefs.get(getContext()).putNotificationFlag(isChecked);
+            prefs.putNotificationFlag(isChecked);
             binding.headsUpSwitchRow.setEnabled(isChecked);
         }));
         binding.headsUpSwitchRow.setEnabled(shouldNotify);
 
-        boolean shouldShowLocalTime = DefaultPrefs.get(getContext()).getShowLocalTimeFlag(false);
-        binding.localTimeSwitchRow.init(shouldShowLocalTime, ((buttonView, isChecked) -> {
-            DefaultPrefs.get(getContext()).putShowLocalTimeFlag(isChecked);
+        binding.localTimeSwitchRow.init(prefs.getShowLocalTimeFlag(), ((buttonView, isChecked) -> {
+            prefs.putShowLocalTimeFlag(isChecked);
         }));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            boolean headsUp = DefaultPrefs.get(getContext()).getHeadsUpFlag(true);
+            boolean headsUp = prefs.getHeadsUpFlag();
             binding.headsUpSwitchRow.init(headsUp, (v, isChecked) -> {
-                DefaultPrefs.get(getContext()).putHeadsUpFlag(isChecked);
+                prefs.putHeadsUpFlag(isChecked);
             });
             binding.headsUpSwitchRow.setVisibility(View.VISIBLE);
             binding.headsUpBorder.setVisibility(View.VISIBLE);

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SettingsFragment.java
@@ -11,7 +11,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -81,7 +80,7 @@ public class SettingsFragment extends BaseFragment {
     }
 
     private void showLanguagesDialog() {
-        List<String> languageIds = Arrays.asList(LocaleUtil.SUPPORT_LANG);
+        List<String> languageIds = LocaleUtil.SUPPORT_LANG;
         List<String> languages = Observable.from(languageIds)
                 .map(languageId -> LocaleUtil.getLanguage(getActivity(), languageId, languageId))
                 .toList()

--- a/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
@@ -4,13 +4,13 @@ import com.rejasupotaro.android.kvs.annotations.Key;
 import com.rejasupotaro.android.kvs.annotations.Table;
 
 @Table(name = "io.github.droidkaigi.confsched_preferences")
-public abstract class DefaultPrefsSchema {
+public interface DefaultPrefsSchema {
     @Key(name = "current_language_id")
-    final String languageId = "";
+    String languageId = "";
     @Key(name = "notification_setting")
-    final boolean notificationFlag = true;
+    boolean notificationFlag = true;
     @Key(name = "heads_up_setting")
-    final boolean headsUpFlag = true;
+    boolean headsUpFlag = true;
     @Key(name = "show_local_time")
-    final boolean showLocalTimeFlag = false;
+    boolean showLocalTimeFlag = false;
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
@@ -5,12 +5,12 @@ import com.rejasupotaro.android.kvs.annotations.Table;
 
 @Table(name = "io.github.droidkaigi.confsched_preferences")
 public abstract class DefaultPrefsSchema {
-    @Key("current_language_id")
+    @Key(name = "current_language_id")
     String languageId;
-    @Key("notification_setting")
+    @Key(name = "notification_setting")
     boolean notificationFlag;
-    @Key("heads_up_setting")
+    @Key(name = "heads_up_setting")
     boolean headsUpFlag;
-    @Key("show_local_time")
+    @Key(name = "show_local_time")
     boolean showLocalTimeFlag;
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
@@ -8,9 +8,9 @@ public abstract class DefaultPrefsSchema {
     @Key(name = "current_language_id")
     String languageId;
     @Key(name = "notification_setting")
-    boolean notificationFlag;
+    final boolean notificationFlag = true;
     @Key(name = "heads_up_setting")
-    boolean headsUpFlag;
+    final boolean headsUpFlag = true;
     @Key(name = "show_local_time")
-    boolean showLocalTimeFlag;
+    final boolean showLocalTimeFlag = false;
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/prefs/DefaultPrefsSchema.java
@@ -6,7 +6,7 @@ import com.rejasupotaro.android.kvs.annotations.Table;
 @Table(name = "io.github.droidkaigi.confsched_preferences")
 public abstract class DefaultPrefsSchema {
     @Key(name = "current_language_id")
-    String languageId;
+    final String languageId = "";
     @Key(name = "notification_setting")
     final boolean notificationFlag = true;
     @Key(name = "heads_up_setting")

--- a/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/receiver/SessionScheduleReceiver.java
@@ -26,7 +26,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        boolean shouldNotify = DefaultPrefs.get(context).getNotificationFlag(true);
+        boolean shouldNotify = DefaultPrefs.get(context).getNotificationFlag();
         if (!shouldNotify) {
             return;
         }
@@ -46,7 +46,7 @@ public class SessionScheduleReceiver extends BroadcastReceiver {
         String title = context.getResources().getQuantityString(
                 R.plurals.schedule_notification_title, REMIND_MINUTES, REMIND_MINUTES);
 
-        boolean headsUp = DefaultPrefs.get(context).getHeadsUpFlag(true);
+        boolean headsUp = DefaultPrefs.get(context).getHeadsUpFlag();
 
         Notification notification = new NotificationCompat.Builder(context)
                 .setContentIntent(pendingIntent)

--- a/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
@@ -125,7 +125,7 @@ public class LocaleUtil {
 
     public static TimeZone getDisplayTimeZone(Context context) {
         TimeZone defaultTimeZone = TimeZone.getDefault();
-        boolean shouldShowLocalTime = DefaultPrefs.get(context).getShowLocalTimeFlag(false);
+        boolean shouldShowLocalTime = DefaultPrefs.get(context).getShowLocalTimeFlag();
         return (shouldShowLocalTime && defaultTimeZone != null) ? defaultTimeZone : CONFERENCE_TIMEZONE;
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/LocaleUtil.java
@@ -5,7 +5,6 @@ import android.content.res.Configuration;
 import android.support.annotation.NonNull;
 import android.support.v4.text.TextUtilsCompat;
 import android.support.v4.view.ViewCompat;
-import android.text.TextUtils;
 import android.util.Log;
 
 import java.text.DateFormat;
@@ -13,6 +12,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -25,7 +25,7 @@ public class LocaleUtil {
     public static final String LANG_JA_ID = "ja";
     public static final String LANG_AR_ID = "ar";
     public static final String LANG_KO_ID = "ko";
-    public static final String[] SUPPORT_LANG = {LANG_EN_ID, LANG_JA_ID, LANG_AR_ID, LANG_KO_ID};
+    public static final List<String> SUPPORT_LANG = Arrays.asList(LANG_EN_ID, LANG_JA_ID, LANG_AR_ID, LANG_KO_ID);
 
     private static final String TAG = LocaleUtil.class.getSimpleName();
 
@@ -70,22 +70,14 @@ public class LocaleUtil {
     }
 
     public static String getCurrentLanguageId(Context context) {
+        // This value would be stored language id or empty.
         String languageId = DefaultPrefs.get(context).getLanguageId();
-        try {
-            if (TextUtils.isEmpty(languageId)) {
-                languageId = Locale.getDefault().getLanguage().toLowerCase();
-            }
-            if (!Arrays.asList(SUPPORT_LANG).contains(languageId)) {
-                languageId = LANG_EN_ID;
-            }
-        } catch (Exception e) {
-            Log.e(TAG, e.toString());
-        } finally {
-            if (TextUtils.isEmpty(languageId)) {
-                languageId = LANG_EN_ID;
-            }
+        if (languageId.isEmpty()) {
+            languageId = Locale.getDefault().getLanguage().toLowerCase();
         }
-        return languageId;
+
+        // If retrieved language id is not supported, fallback to the default value (English).
+        return SUPPORT_LANG.contains(languageId) ? languageId : LANG_EN_ID;
     }
 
     public static String getCurrentLanguage(Context context) {


### PR DESCRIPTION
# Overview

I updated KVS schema from `3.0.0` to `5.0.0`.

# New feature: Default value

Some features were introduced in this update. A change that affects to this project is [Support default value](https://github.com/rejasupotaro/kvs-schema/pull/18). If a field is difined as a constant, KVS schema reads and assigns the value to the generated class as a default value like below.

```java
// Schema class
@Table(name = "io.github.droidkaigi.confsched_preferences")
public abstract class DefaultPrefsSchema {
    @Key(name = "notification_setting")
    final boolean notificationFlag = true;
```

```java
// Generated class
  public boolean getNotificationFlag() {
    return getBoolean("notification_setting", true); // A constant value we set is specified.
  }
```

So we don't have to specify default values expressly.

```java
prefs.getNotificationFlag(); // It returns true if `notification_setting` is not stored.
prefs.getNotificationFlag(true); // Specifying default value is also fine.
```