### PR TITLE
Add gradle-versions-plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'io.fabric'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.vanniktech.android.apk.size'
+apply plugin: 'com.github.ben-manes.versions'
 
 // Manifest version
 def versionMajor = 1

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
         classpath 'me.tatarka:gradle-retrolambda:3.2.4'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'io.fabric.tools:gradle:1.21.2'
-        // apk size
         classpath 'com.vanniktech:gradle-android-apk-size-plugin:0.2.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
     }
 
     configurations.classpath.exclude group: 'com.android.tools.external.lombok'


### PR DESCRIPTION
## done

- I have added [gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugin). This allows all contributors to easily check whether the libraries this app depend on are all up-to-date :)

- Remove short `apk size` comment (If anybody does not like this modification I can revert this 🙇 )

## memo

Maybe in the near future we can integrate it to Circle CI and run the command and check the library updates regularly.

http://www.slideshare.net/shinobuokano7/gradle-pluginci-62464447/19?src=clipshare

Also, here is the result when I ran the command 

```
./gradlew delendencyUpdates
```

```
The following dependencies exceed the version found at the milestone revision level:
 - com.android.databinding:adapters [1.1 <- 1.0-rc3]
 - com.android.databinding:library [1.1 <- 1.0-rc3]

The following dependencies have later milestone versions:
 - com.android.databinding:baseLibrary [2.1.2 -> 2.2.0-alpha3]
 - com.android.databinding:compiler [2.1.2 -> 2.2.0-alpha3]
 - com.android.support:animated-vector-drawable [23.2.0 -> 24.0.0-beta1]
 - com.android.support:appcompat-v7 [23.2.0 -> 24.0.0-beta1]
 - com.android.support:cardview-v7 [23.2.0 -> 24.0.0-beta1]
 - com.android.support:customtabs [23.2.0 -> 24.0.0-beta1]
 - com.android.support:design [23.2.0 -> 24.0.0-beta1]
 - com.android.support:recyclerview-v7 [23.2.0 -> 24.0.0-beta1]
 - com.android.support:support-annotations [23.2.0 -> 24.0.0-beta1]
 - com.android.support:support-v4 [23.2.0 -> 24.0.0-beta1]
 - com.android.support:support-vector-drawable [23.2.0 -> 24.0.0-beta1]
 - com.android.support.test:rules [0.4.1 -> 0.5]
 - com.android.support.test:runner [0.4.1 -> 0.5]
 - com.android.support.test.espresso:espresso-core [2.2.1 -> 2.2.2]
 - com.android.support.test.espresso:espresso-intents [2.2.1 -> 2.2.2]
 - com.facebook.stetho:stetho [1.3.0 -> 1.3.1]
 - com.github.gfx.android.orma:orma [2.3.2 -> 2.5.0]
 - com.github.gfx.android.orma:orma-processor [2.3.2 -> 2.5.0]
 - com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation [3.0.8 -> 3.1.0]
 - com.github.hotchemi:permissionsdispatcher [2.1.2 -> 2.1.3]
 - com.github.hotchemi:permissionsdispatcher-processor [2.1.2 -> 2.1.3]
 - com.github.jd-alexander:LikeButton [0.1.9 -> 0.2.0]
 - com.github.ozodrukh:CircularReveal [1.3.1 -> 2.0.1]
 - com.google.android.gms:play-services-analytics [8.4.0 -> 9.0.2]
 - com.google.android.gms:play-services-maps [8.4.0 -> 9.0.2]
 - com.google.code.gson:gson [2.6.1 -> 2.6.2]
 - com.google.dagger:dagger [2.2 -> 2.4]
 - com.google.dagger:dagger-compiler [2.2 -> 2.4]
 - javax.annotation:jsr250-api [1.0 -> 1.0-20050927.133100]
 - net.opacapp:multiline-collapsingtoolbar [1.0.0 -> 1.0.1]
 - org.mockito:mockito-all [1.10.19 -> 2.0.2-beta]
 - org.parceler:parceler [1.0.4 -> 1.1.5]
 - org.parceler:parceler-api [1.0.4 -> 1.1.5]
```