### PR TITLE
Fixed the app crashes on Pre-Lollipop devices.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     compile 'com.squareup.retrofit2:converter-gson:2.0.2'
 
     compile 'org.apmem.tools:layouts:1.10@aar'
-    compile 'com.github.jd-alexander:LikeButton:0.1.9'
+    compile 'com.github.jd-alexander:LikeButton:0.2.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.0.0'
     compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') {
         transitive = true;


### PR DESCRIPTION
See the issue https://github.com/jd-alexander/LikeButton/issues/19 cause of the problem that was fixed in v0.2.0.