### PR TITLE
Update RxJava 1.1.5->1.1.7, RxAndroid 1.2.0->1.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,8 +147,8 @@ dependencies {
     provided 'javax.annotation:jsr250-api:1.0'
     compile 'com.google.code.gson:gson:2.6.1'
     compile "com.squareup.okhttp3:okhttp:3.3.1"
-    compile 'io.reactivex:rxjava:1.1.5'
-    compile 'io.reactivex:rxandroid:1.2.0'
+    compile 'io.reactivex:rxjava:1.1.7'
+    compile 'io.reactivex:rxandroid:1.2.1'
     compile "com.jakewharton.threetenabp:threetenabp:1.0.3"
     compile "org.parceler:parceler-api:1.0.4"
     apt "org.parceler:parceler:1.0.4"


### PR DESCRIPTION
## Done

In this PR I have updated two libraries: RxJava and RxAndroid.

- [RxJava from 1.1.5 to 1.1.7](https://github.com/ReactiveX/RxJava/blob/1.x/CHANGES.md#version-117---july-10-2016-maven)
- [RxAndroid from 1.2.0 to 1.2.1](https://github.com/ReactiveX/RxAndroid/blob/master/CHANGES.md#version-121---june-16th-2016)

I have manually tested by myself by installing the app with `developDebug` and it seems ok, but just in case I would like other developers to check to make sure that this PR does not break anything. 🙇 