### PR TITLE
Migrate to flexbox-layout from flowlayout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
 
-    compile 'org.apmem.tools:layouts:1.10@aar'
+    compile 'com.google.android:flexbox:0.2.3'
     compile 'com.github.jd-alexander:LikeButton:0.2.0'
     compile 'net.opacapp:multiline-collapsingtoolbar:1.0.0'
     compile('com.github.ozodrukh:CircularReveal:1.3.1@aar') {

--- a/app/src/main/java/io/github/droidkaigi/confsched/fragment/SponsorsFragment.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/fragment/SponsorsFragment.java
@@ -8,7 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.apmem.tools.layouts.FlowLayout;
+import com.google.android.flexbox.FlexboxLayout;
 
 import javax.inject.Inject;
 
@@ -56,7 +56,7 @@ public class SponsorsFragment extends BaseFragment {
                 .forEach(sponsor -> addView(sponsor, binding.normalContainer));
     }
 
-    private void addView(Sponsor sponsor, FlowLayout container) {
+    private void addView(Sponsor sponsor, FlexboxLayout container) {
         SponsorImageView imageView = new SponsorImageView(getActivity());
         imageView.bindData(sponsor, v -> {
             if (TextUtils.isEmpty(sponsor.url))
@@ -64,8 +64,8 @@ public class SponsorsFragment extends BaseFragment {
             analyticsTracker.sendEvent("sponsor", sponsor.url);
             AppUtil.showWebPage(getActivity(), sponsor.url);
         });
-        FlowLayout.LayoutParams params = new FlowLayout.LayoutParams(
-                FlowLayout.LayoutParams.WRAP_CONTENT, FlowLayout.LayoutParams.WRAP_CONTENT);
+        FlexboxLayout.LayoutParams params = new FlexboxLayout.LayoutParams(
+                FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT);
         int margin = (int) getResources().getDimension(R.dimen.spacing_small);
         params.setMargins(margin, margin, 0, 0);
         container.addView(imageView, params);

--- a/app/src/main/java/io/github/droidkaigi/confsched/util/DataBindingAttributeUtil.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/util/DataBindingAttributeUtil.java
@@ -5,11 +5,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.view.GravityCompat;
-import android.support.v4.view.ViewCompat;
 import android.text.TextUtils;
 import android.text.util.Linkify;
-import android.view.Gravity;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -17,8 +14,6 @@ import android.widget.TextView;
 import com.squareup.picasso.Picasso;
 
 import net.opacapp.multilinecollapsingtoolbar.CollapsingToolbarLayout;
-
-import org.apmem.tools.layouts.FlowLayout;
 
 import java.util.Date;
 
@@ -105,16 +100,6 @@ public class DataBindingAttributeUtil {
     public static void setSessionFab(FloatingActionButton fab, @NonNull Session session) {
         fab.setRippleColor(ContextCompat.getColor(fab.getContext(), session.category.getPaleColorResId()));
         fab.setSelected(session.checked);
-    }
-
-    @BindingAdapter("forceRtlDirection")
-    public static void setForceRtlDirection(FlowLayout flowLayout, boolean isCenterVertical) {
-        if (LocaleUtil.shouldRtl()) {
-            ViewCompat.setLayoutDirection(flowLayout, ViewCompat.LAYOUT_DIRECTION_RTL);
-
-            int gravity = isCenterVertical ? GravityCompat.START | Gravity.CENTER_VERTICAL : GravityCompat.START;
-            flowLayout.setGravity(gravity);
-        }
     }
 
     @BindingAdapter("textRtlConsidered")

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -107,7 +107,7 @@
                     android:textSize="@dimen/text"
                     app:sessionDetailTimeRange="@{session}" />
 
-                <org.apmem.tools.layouts.FlowLayout
+                <com.google.android.flexbox.FlexboxLayout
                     android:id="@+id/tag_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -116,7 +116,8 @@
                     android:layout_marginRight="@dimen/spacing"
                     android:layout_marginStart="@dimen/spacing"
                     android:layout_marginTop="@dimen/spacing_xsmall_negative"
-                    app:forceRtlDirection="@{true}">
+                    app:flexDirection="row"
+                    app:flexWrap="wrap">
 
                     <TextView
                         android:id="@+id/txt_place"
@@ -145,7 +146,7 @@
                         android:text="@{session.getLanguageResId()}"
                         android:textColor="@color/grey600" />
 
-                </org.apmem.tools.layouts.FlowLayout>
+                </com.google.android.flexbox.FlexboxLayout>
 
                 <View
                     style="@style/Border"

--- a/app/src/main/res/layout/fragment_sponsors.xml
+++ b/app/src/main/res/layout/fragment_sponsors.xml
@@ -18,7 +18,7 @@
                 style="@style/SponsorCategory"
                 android:text="@string/sponsor_category_platinum" />
 
-            <org.apmem.tools.layouts.FlowLayout
+            <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/platinum_container"
                 style="@style/SponsorImagesContainer" />
 
@@ -26,7 +26,7 @@
                 style="@style/SponsorCategory"
                 android:text="@string/sponsor_category_video" />
 
-            <org.apmem.tools.layouts.FlowLayout
+            <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/video_container"
                 style="@style/SponsorImagesContainer" />
 
@@ -34,7 +34,7 @@
                 style="@style/SponsorCategory"
                 android:text="@string/sponsor_category_food" />
 
-            <org.apmem.tools.layouts.FlowLayout
+            <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/foods_container"
                 style="@style/SponsorImagesContainer" />
 
@@ -42,7 +42,7 @@
                 style="@style/SponsorCategory"
                 android:text="@string/sponsor_category_normal" />
 
-            <org.apmem.tools.layouts.FlowLayout
+            <com.google.android.flexbox.FlexboxLayout
                 android:id="@+id/normal_container"
                 style="@style/SponsorImagesContainer"
                 android:layout_marginBottom="@dimen/spacing_large" />

--- a/app/src/main/res/layout/item_session.xml
+++ b/app/src/main/res/layout/item_session.xml
@@ -68,13 +68,14 @@
                     android:textSize="@dimen/text_small"
                     app:sessionTimeRange="@{session}" />
 
-                <org.apmem.tools.layouts.FlowLayout
+                <com.google.android.flexbox.FlexboxLayout
                     android:id="@+id/tag_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/txt_time"
                     android:layout_marginTop="@dimen/spacing_xsmall"
-                    app:forceRtlDirection="@{true}">
+                    app:flexDirection="row"
+                    app:flexWrap="wrap">
 
                     <TextView
                         android:id="@+id/txt_place"
@@ -103,7 +104,7 @@
                         android:text="@{session.getLanguageResId()}"
                         android:textColor="@color/grey600" />
 
-                </org.apmem.tools.layouts.FlowLayout>
+                </com.google.android.flexbox.FlexboxLayout>
 
                 <TextView
                     android:id="@+id/txt_conflict"

--- a/app/src/main/res/values/styles_sponsor.xml
+++ b/app/src/main/res/values/styles_sponsor.xml
@@ -21,7 +21,11 @@
         <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/spacing</item>
         <item name="android:paddingLeft">@dimen/spacing</item>
         <item name="android:paddingRight">@dimen/spacing_small</item>
-        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing_small</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/spacing_small
+        </item>
+        <item name="flexDirection">row</item>
+        <item name="flexWrap">wrap</item>
+        <item name="justifyContent">center</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Issue
https://github.com/konifar/droidkaigi2016/issues/404

## Overview
We use flow-layout on category tag view.
Now, we can use really awesome library called [flexbox-layout](https://github.com/google/flexbox-layout).
It's really awesome! Thanks @thagikura ! 👏 

## Screenshot
### LTR
![screenshot_2016-09-15-19-49-31_jpg__540x960_](https://cloud.githubusercontent.com/assets/1269214/18547312/b634ec7e-7b7d-11e6-94e9-79248a29585d.png)

![screenshot_2016-09-15-19-50-04_jpg__1080x1920_](https://cloud.githubusercontent.com/assets/1269214/18547319/c6b54e68-7b7d-11e6-986a-74760b0b66c1.png)

![screenshot_2016-09-15-19-51-37_jpg__1080x1920_](https://cloud.githubusercontent.com/assets/1269214/18547345/e8a12aec-7b7d-11e6-8e57-8ae467ad52ae.png)


### RTL
![screenshot_2016-09-15-19-32-42_jpg__1080x1920_](https://cloud.githubusercontent.com/assets/1269214/18547216/3a76d692-7b7d-11e6-8c73-14534e42f16c.png)

![screenshot_2016-09-15-19-33-11_jpg__1080x1920_](https://cloud.githubusercontent.com/assets/1269214/18547257/67ad94b6-7b7d-11e6-877c-a25f48ae119e.png)

![screenshot_2016-09-15-19-48-09_jpg__1080x1920_](https://cloud.githubusercontent.com/assets/1269214/18547270/7ad59386-7b7d-11e6-9bf9-dbc01f421640.png)

