### PR TITLE
Add session slide url

### DIFF
--- a/app/src/main/res/raw/sessions_ar.json
+++ b/app/src/main/res/raw/sessions_ar.json
@@ -671,7 +671,7 @@
       "name": "غرفة C"
     },
     "language_id": "ja",
-    "slide_url": "",
+    "slide_url": "https://speakerdeck.com/masaki_mori/view-into-the-abyss",
     "movie_url": "https://www.youtube.com/watch?v=cLjbUqmyop0",
     "share_url": "https://droidkaigi.github.io/2016/timetable.html#session-2016-02-19-11-30-12-00-c"
   },

--- a/app/src/main/res/raw/sessions_en.json
+++ b/app/src/main/res/raw/sessions_en.json
@@ -672,7 +672,7 @@
       "name": "Room C"
     },
     "language_id": "ja",
-    "slide_url": "",
+    "slide_url": "https://speakerdeck.com/masaki_mori/view-into-the-abyss",
     "movie_url": "https://www.youtube.com/watch?v=cLjbUqmyop0",
     "share_url": "https://droidkaigi.github.io/2016/timetable.html#session-2016-02-19-11-30-12-00-c"
   },

--- a/app/src/main/res/raw/sessions_ja.json
+++ b/app/src/main/res/raw/sessions_ja.json
@@ -672,7 +672,7 @@
       "name": "ルームC"
     },
     "language_id": "ja",
-    "slide_url": "",
+    "slide_url": "https://speakerdeck.com/masaki_mori/view-into-the-abyss",
     "movie_url": "https://www.youtube.com/watch?v=cLjbUqmyop0",
     "share_url": "https://droidkaigi.github.io/2016/timetable.html#session-2016-02-19-11-30-12-00-c"
   },

--- a/app/src/main/res/raw/sessions_ko.json
+++ b/app/src/main/res/raw/sessions_ko.json
@@ -671,8 +671,8 @@
       "name": "Room C"
     },
     "language_id": "ja",
-    "slide_url": "",
-    "movie_url": "",
+    "slide_url": "https://speakerdeck.com/masaki_mori/view-into-the-abyss",
+    "movie_url": "https://www.youtube.com/watch?v=cLjbUqmyop0",
     "share_url": "https://droidkaigi.github.io/2016/timetable.html#session-2016-02-19-11-30-12-00-c"
   },
   {


### PR DESCRIPTION
close #309 

I happened to find the session slide url! 👍 

https://speakerdeck.com/masaki_mori/view-into-the-abyss

Also, I have found out that the movie url was missing on one of the sessions json files (I am sorry that was my mistake from old PR.. 🙇 ), so I modified to add the movie url in this PR as well.

