### PR TITLE
Update multiline-collapsingtoolbar 1.0.0 -> 1.2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,6 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
-        abortOnError false
     }
 
     aaptOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,7 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
+        abortOnError false
     }
 
     aaptOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,7 @@ dependencies {
 
     compile 'com.google.android:flexbox:0.2.3'
     compile 'com.github.jd-alexander:LikeButton:0.2.0'
-    compile 'net.opacapp:multiline-collapsingtoolbar:1.0.0'
+    compile 'net.opacapp:multiline-collapsingtoolbar:1.2.2'
     compile('com.github.ozodrukh:CircularReveal:2.0.1@aar') {
         transitive = true;
     }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -90,6 +90,7 @@
 
     <style name="SessionDetailToolbarTitle">
         <item name="android:textSize">@dimen/text_xxlarge</item>
+        <item name="android:textColor">@color/white</item>
         <item name="android:maxLines">4</item>
     </style>
 


### PR DESCRIPTION
Library Update: Update multiline-collapsingtoolbar 1.0.0 -> 1.2.2 🎱 

There is no CHANGELOG for this library 😭 
https://github.com/opacapp/multiline-collapsingtoolbar/

*I have added `textColor` specification; set textColor to white for `SessionDetailToolbarTitle` as the text color of session detail titles became black due to the update(I will try to find out why..)

|BEFORE|AFTER|
|:---:|:---:|
|![deployed-one](https://cloud.githubusercontent.com/assets/920911/18856730/67220ed6-8498-11e6-88c2-d2d67efacb2f.gif)|![bullheadnrd90sa1347009272016095107](https://cloud.githubusercontent.com/assets/920911/18856683/ed4d5f70-8497-11e6-9812-8d3e32919c02.gif)|