### PR TITLE
Added gps users-feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <uses-feature android:name="android.hardware.location.gps" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
@@ -33,7 +35,7 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.NOTIFICATION_PREFERENCES"/>
+                <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
## Overview
I added `users-feature` to AndroidManifest.xml.

```xml
<uses-feature android:name="android.hardware.location.gps" />
```

## Background
According to the developer page, we must explicitly declare that `users-feature` if we uses the `ACCESS_FINE_LOCATION`.
https://developer.android.com/guide/topics/manifest/uses-feature-element.html

> Caution: If your app targets Android 5.0 (API level 21) or higher and uses the ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permission in order to receive location updates from the network or a GPS, respectively, you must also explicitly declare that your app uses the android.hardware.location.network or android.hardware.location.gps hardware features.

@hkurokawa announced it on Slack. Thanks!
https://droidkaigi.slack.com/archives/officialapp/p1475140680000159
