### PR TITLE
Upgrade Orma to v3.0.0-rc2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,8 +152,9 @@ dependencies {
     compile "org.parceler:parceler-api:1.0.4"
     apt "org.parceler:parceler:1.0.4"
 
-    apt 'com.github.gfx.android.orma:orma-processor:2.3.2'
-    compile 'com.github.gfx.android.orma:orma:2.3.2'
+    compile 'com.github.gfx.android.orma:orma:3.0.0-rc2'
+    apt 'com.github.gfx.android.orma:orma-processor:3.0.0-rc2'
+
     compile 'com.github.hotchemi:permissionsdispatcher:2.2.0'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.2.0'
 

--- a/app/src/main/java/io/github/droidkaigi/confsched/dao/ContributorDao.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/dao/ContributorDao.java
@@ -2,8 +2,6 @@ package io.github.droidkaigi.confsched.dao;
 
 import android.support.annotation.NonNull;
 
-import com.github.gfx.android.orma.TransactionTask;
-
 import java.util.List;
 
 import javax.inject.Inject;
@@ -32,11 +30,6 @@ public class ContributorDao {
     }
 
     public void upserterAll(@NonNull List<Contributor> contributors) {
-        orma.transactionAsync(new TransactionTask() {
-            @Override
-            public void execute() throws Exception {
-                contributorRelation().upserter().executeAll(contributors);
-            }
-        });
+        orma.transactionAsync(() -> contributorRelation().upserter().executeAll(contributors)).subscribe();
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched/dao/SessionDao.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/dao/SessionDao.java
@@ -1,7 +1,5 @@
 package io.github.droidkaigi.confsched.dao;
 
-import com.github.gfx.android.orma.TransactionTask;
-
 import java.util.List;
 
 import javax.inject.Inject;
@@ -104,12 +102,7 @@ public class SessionDao {
 
 
     public void updateAllAsync(List<Session> sessions) {
-        orma.transactionAsync(new TransactionTask() {
-            @Override
-            public void execute() throws Exception {
-                updateAllSync(sessions);
-            }
-        });
+        orma.transactionAsync(() -> updateAllSync(sessions)).subscribe();
     }
 
     public void updateChecked(Session session) {

--- a/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched/di/AppModule.java
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched.di;
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
 
+import com.github.gfx.android.orma.AccessThreadConstraint;
 import com.github.gfx.android.orma.migration.ManualStepMigration;
 
 import android.app.Application;
@@ -99,6 +100,7 @@ public class AppModule {
                         helper.renameColumn("Session", "categoryId", "category");
                     }
                 })
+                .writeOnMainThread(AccessThreadConstraint.WARNING)
                 .build();
     }
 


### PR DESCRIPTION
Upgrade Orma with newly-designed internal schemas (see [my post](http://gfx.hatenablog.com/entry/2016/10/10/190804)).

I have also fixed transactions because v3 has removed deprecated `transactionAsync()` methods.

ref. [diff v2.3.2...v3.0.0-rc2](https://github.com/gfx/Android-Orma/compare/v2.3.1...v3.0.0-rc2)