### PR TITLE
Remove android-apt plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ import com.android.ddmlib.DdmPreferences
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'me.tatarka.retrolambda'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.vanniktech.android.apk.size'
 apply plugin: 'com.github.ben-manes.versions'
 
@@ -142,7 +141,7 @@ dependencies {
     compile "com.google.android.gms:play-services-maps:${play_services_lib_version}"
 
     compile 'com.google.dagger:dagger:2.7'
-    apt 'com.google.dagger:dagger-compiler:2.7'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.7'
     provided 'javax.annotation:jsr250-api:1.0'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
@@ -150,16 +149,16 @@ dependencies {
     compile 'io.reactivex:rxandroid:1.2.1'
     compile "com.jakewharton.threetenabp:threetenabp:1.0.4"
     compile "org.parceler:parceler-api:1.0.4"
-    apt "org.parceler:parceler:1.0.4"
+    annotationProcessor "org.parceler:parceler:1.0.4"
 
     compile 'com.github.gfx.android.orma:orma:3.0.0-rc2'
-    apt 'com.github.gfx.android.orma:orma-processor:3.0.0-rc2'
+    annotationProcessor 'com.github.gfx.android.orma:orma-processor:3.0.0-rc2'
 
     compile 'com.github.hotchemi:permissionsdispatcher:2.2.0'
-    apt 'com.github.hotchemi:permissionsdispatcher-processor:2.2.0'
+    annotationProcessor 'com.github.hotchemi:permissionsdispatcher-processor:2.2.0'
 
     compile 'com.rejasupotaro:kvs-schema:5.0.1'
-    apt 'com.rejasupotaro:kvs-schema-compiler:5.0.1'
+    annotationProcessor 'com.rejasupotaro:kvs-schema-compiler:5.0.1'
 
     compile "com.squareup.picasso:picasso:2.5.2"
     compile 'com.squareup.retrofit2:retrofit:2.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'io.fabric.tools:gradle:1.21.2'


### PR DESCRIPTION
ref: https://bitbucket.org/hvisser/android-apt/wiki/Migration

## Overview

- Update gradle plugin to 2.2.1.
- And also remove android-apt plugin since android gradle plugin started annotation processing support natively from 2.2.
  - See https://bitbucket.org/hvisser/android-apt/wiki/Migration